### PR TITLE
ilm: lock: Refine drive state machine

### DIFF
--- a/src/idm_wrapper.h
+++ b/src/idm_wrapper.h
@@ -22,8 +22,10 @@ int idm_drive_renew_lock(char *lock_id, int mode,
                          char *host_id, char *drive);
 int idm_drive_break_lock(char *lock_id, int mode, char *host_id,
 			 char *drive, uint64_t timeout);
-int idm_drive_write_lvb(char *lock_id, void *lvb, int lvb_size, char *drive);
-int idm_drive_read_lvb(char *lock_id, void *lvb, int lvb_size, char *drive);
+int idm_drive_write_lvb(char *lock_id, char *host_id,
+			void *lvb, int lvb_size, char *drive);
+int idm_drive_read_lvb(char *lock_id, char *host_id,
+		       void *lvb, int lvb_size, char *drive);
 int idm_drive_lock_count(char *lock_id, int *count, char *drive);
 int idm_drive_lock_mode(char *lock_id,
 			int *mode,


### PR DESCRIPTION
This patch refines the drive state machine.  Now the drive has three
states: NOACCESS, ACCESSED, FAILED; this patch defines the state
machine with more clear semantics.

NOACCESS: means the lock has not been acquired;
ACCESSED: means the lock has been acquired with properly accessing;
FAILED: means the lock has been acquired but with I/O error.

Also added more detailed comment for the detailed state transition.

Signed-off-by: Leo Yan <leo.yan@linaro.org>