### PR TITLE
ilm: log: Support log rotation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -78,3 +78,4 @@ install: all
 	cp -a $(LIB_TARGET).so.$(SOMAJOR) $(DESTDIR)/$(LIBDIR)
 	$(INSTALL) -c -m 644 $(HEADER_TARGET) $(DESTDIR)/$(HEADIR)
 	$(INSTALL) -c -m 644 seagate_ilm.service /usr/lib/systemd/system/
+	$(INSTALL) -c -m 644 logrotate.ilm /etc/logrotate.d/seagate_ilm

--- a/src/logrotate.ilm
+++ b/src/logrotate.ilm
@@ -1,0 +1,10 @@
+/run/seagate_ilm/seagate_ilm.log {
+    rotate 3
+    missingok
+    copytruncate
+    size 10M
+    compress
+    compresscmd /usr/bin/xz
+    uncompresscmd /usr/bin/unxz
+    compressext .xz
+}


### PR DESCRIPTION
This patch is to support log rotation; when the log file is bigger
than 10MB, the log will be compressed and trucated.  So can avoid to
consume too big disk space for log files.

Signed-off-by: Leo Yan <leo.yan@linaro.org>