### PR TITLE
ilm: lock: Fix the wrong freeing memory

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -259,8 +259,6 @@ drive_fail:
 			free(drive->path[j]);
 	}
 
-	for (i = 0; i < copied; i++)
-		free(lock->drive[i].path);
 	free(lock);
 	free(wwn_arr);
 	return NULL;


### PR DESCRIPTION
The field "ilm_drive::path" is an array to record paths for single
drive, this array is allocated when the struct "ilm_drive" is allocated,
so don't free the path array for the error handling, struct "ilm_drive"
is resident in struct "ilm_lock", the struct "ilm_drive" and its field
"ilm_drive::path" will be freed at once when free struct "ilm_lock".

Signed-off-by: Leo Yan <leo.yan@linaro.org>