### PR TITLE
ilm: raid_lock: Handle for drive firmware updating

### DIFF
--- a/src/raid_lock.c
+++ b/src/raid_lock.c
@@ -247,6 +247,17 @@ struct _raid_state_transition state_transition[] = {
 	},
 
 	/*
+	 * If the lock has been acquired, afterwards, if the lock entry has
+	 * been removed from the drive firwarem, convert to the IDM_INIT state,
+	 * try to acquire the mutex again.
+	 */
+	{
+		.curr	= IDM_LOCK,
+		.result	= -ENOENT,
+		.next	= IDM_INIT,
+	},
+
+	/*
 	 * This is a special case which is used for the normal unlock flow.
 	 */
 	{


### PR DESCRIPTION
It's possible that the firmware is updated on the fly, after the
firmware has been updated, all mutexes entries will be lost.  For this
case, the lock space thread will fail to renew the mutexes since the
drive firmware has reset all mutexes.

We can utilize the lockspace thread to renew the mutexes and thus it
can acquire the mutex after the drive firmware has been upgraded. 
This patch is to handle the drive firmware upgrading, if the drive
firmware reports -ENOENT, the lock manager will change the drive
state to "IDM_INIT", thus the lock manager will re-acquire the mutex.

Signed-off-by: Leo Yan <leo.yan@linaro.org>