### PR TITLE
ilm: lock: Support max to 512 drive paths

### DIFF
--- a/python/lib_ilm.i
+++ b/python/lib_ilm.i
@@ -13,7 +13,7 @@
 %apply int *OUTPUT { int *version };
 
 %{
-#define ILM_DRIVE_MAX_NUM       32
+#define ILM_DRIVE_MAX_NUM       512
 
 struct idm_lock_id {
         char vg_uuid[32];
@@ -47,7 +47,7 @@ int ilm_start_renew(int sock);
 int ilm_inject_fault(int sock, int percentage);
 %}
 
-#define ILM_DRIVE_MAX_NUM       32
+#define ILM_DRIVE_MAX_NUM       512
 
 #define IDM_MODE_UNLOCK         0
 #define IDM_MODE_EXCLUSIVE      1

--- a/src/ilm.h
+++ b/src/ilm.h
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <uuid/uuid.h>
 
-#define ILM_DRIVE_MAX_NUM	32
+#define ILM_DRIVE_MAX_NUM		512
 
 #define IDM_MODE_UNLOCK			0
 #define IDM_MODE_EXCLUSIVE		1
@@ -26,7 +26,7 @@ struct idm_lock_op {
 	uint32_t mode;
 
 	uint32_t drive_num;
-	const char *drives[ILM_DRIVE_MAX_NUM];
+	char *drives[ILM_DRIVE_MAX_NUM];
 
 	int timeout; /* -1 means unlimited timeout */
 };


### PR DESCRIPTION
Extend path list from 32 to 512 so can meet the requirement for LVM2.

Signed-off-by: Leo Yan <leo.yan@linaro.org>