### PR TITLE
ilm: doc: Add description for failure cases of upstreaming

### DIFF
--- a/doc/lvm_test.md
+++ b/doc/lvm_test.md
@@ -23,6 +23,14 @@
   thin-large.sh
 ```
 
+- Updated: new failure cases for upstreaming LVM2
+
+```
+  cache-single-split.sh
+  lvcreate-thin-limits.sh
+  metadata-full.sh
+```
+
 ## Comparision with sanlock lock manager
 
 There have 8 cases in LVM which cannot pass with IDM lock manager,
@@ -86,3 +94,26 @@ This can give us more confidence for the testing result.
   [ 0:58] #vgchange-partial.sh:26+ vgchange --addtag foo @PREFIX@vg
   [ 0:58]   VG @PREFIX@vg lock failed: error -221
 ```
+
+## Failures on the LVM2 mainline code
+
+- cache-single-split.sh: unknown device name after delete the PV's device mapper
+```
+[ 1:05] lvconvert --uncache $vg/$lv1
+[ 1:05] #cache-single-split.sh:376+ lvconvert --uncache LVMTEST2744vg/LV1
+[ 1:05]   WARNING: Couldn't find device with uuid HMj9qK-QALs-1Fgd-rpR2-OtF9-muvU-Lrnx62.
+[ 1:05]   WARNING: VG LVMTEST2744vg is missing PV HMj9qK-QALs-1Fgd-rpR2-OtF9-muvU-Lrnx62 (last written to /dev/mapper/LVMTEST2744pv2).
+[ 1:05]   WARNING: Couldn't find device with uuid HMj9qK-QALs-1Fgd-rpR2-OtF9-muvU-Lrnx62.
+[ 1:05]   WARNING: Couldn't find device with uuid HMj9qK-QALs-1Fgd-rpR2-OtF9-muvU-Lrnx62.
+[ 1:05]   WARNING: This metadata update is NOT backed up.
+[ 1:05]   LV LVMTEST2744vg/LV2 lock failed: storage errors for sanlock leases
+[ 1:05]   Logical volume LVMTEST2744vg/LV1 is not cached and LVMTEST2744vg/LV2 is removed.
+```
+
+- lvcreate-thin-limits.sh: depends on big disk
+```
+[ 0:17] #lvcreate-thin-limits.sh:38+ lvcreate -l100%PV --name LV1 LVMTEST20657vg /dev/mapper/LVMTEST20657pv2
+[ 0:17]   VG LVMTEST20657vg lock failed: storage errors for sanlock leases
+```
+
+- metadata-full.sh: Need to specify the log line with option "LVM_LOG_FILE_MAX_LINES=2000000"


### PR DESCRIPTION
Add more description for failure cases when upstream IDM code for LVM2.

Signed-off-by: Leo Yan <leo.yan@linaro.org>

-----
[View rendered doc/lvm_test.md](https://github.com/Leo-Yan/propeller/blob/add_description_for_failure_case/doc/lvm_test.md)