### PR TITLE
ilm: uuid: Fix the compilation error for missing header

### DIFF
--- a/src/uuid.c
+++ b/src/uuid.c
@@ -9,6 +9,7 @@
 
 #include <string.h>
 
+#include "log.h"
 #include "uuid.h"
 
 int ilm_id_write_format(const char *id, char *buffer, size_t size)


### PR DESCRIPTION
Include header "log.h" in uuid.c for fixing compilation error.

Signed-off-by: Leo Yan <leo.yan@linaro.org>