### PR TITLE
ilm: main: Fix segment fault during initialization

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,8 @@ static int ilm_read_args(int argc, char *argv[])
 	int i, ret;
 
 	/* Check the building version */
-	if (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-V")) {
+	if (argc == 2 &&
+	    (!strcmp(argv[1], "--version") || !strcmp(argv[1], "-V"))) {
 		printf("%s %s (%s %s)\n", argv[0], VERSION, __DATE__, __TIME__);
 		exit(EXIT_SUCCESS);
 	}


### PR DESCRIPTION
When launch daemon with command "./seagate_ilm", the program exists
abnormally.  This is because the command doesn't check the argument
count and directly access argv[1].

Add checking for argument count before checking argv[1].

Signed-off-by: Leo Yan <leo.yan@linaro.org>