### PR TITLE
lockspace:ilm_lockspace_thread: Change variable type

### DIFF
--- a/src/lockspace.c
+++ b/src/lockspace.c
@@ -50,7 +50,8 @@ static void *ilm_lockspace_thread(void *data)
 {
 	struct ilm_lockspace *ls = data;
 	struct ilm_lock *lock;
-	int exit, ret, now;
+	int exit, ret;
+	uint64_t now;
 
 	while (1) {
 		pthread_mutex_lock(&ls->mutex);


### PR DESCRIPTION
Changed now variable from int to uint64_t for comparison with last_renewal_success.
This solved an issue with long running machines having the time value for `now` cropped to a smaller value. 

Signed-off-by: Brandon O'Hare <brandon.ohare@seagate.com>