### PR TITLE
drive.c : drive_thd_fn : add udev change handler

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -766,7 +766,12 @@ static void *drive_thd_fn(void *arg __maybe_unused)
 				ilm_scsi_add_drive_path(dev_node, sg, wwn);
 			} else if (!strcmp(action, "remove")) {
 				ilm_scsi_del_drive_path(dev_node);
+			} else if (!strcmp(action, "change")) {
+				ilm_scsi_list_exit();
+				drive_thd_done = 0;
+				ilm_scsi_list_init();
 			}
+				
 
 			ilm_scsi_dump_nodes();
 


### PR DESCRIPTION
udev sends 'change' commands to the drive thread, this needs to be handled by refreshing the drive list as one of the drives have changed in this scenario.

Using the existing methods inside drive.c, I set up a statement to clear the list, reset the "done" flag, and reinitialize the drive list.

Signed-off-by: Brandon O'Hare <brandon.ohare@seagate.com>