### PR TITLE
Drive.c: ilm_scsi_list_rescan: Bracket fix

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -886,9 +886,10 @@ int ilm_scsi_list_rescan(void)
 		}
 
 		ret = ilm_scsi_find_block_node(blk_path, &blk_str);
-		if (ret < 0)
+		if (ret < 0){
 			ilm_log_err("Not a block device");
 			continue;
+		}
 
 		snprintf(dev_node, sizeof(dev_node), "/dev/%s", blk_str);
 		free(blk_str);


### PR DESCRIPTION
Without brackets the continue statement ran directly after, causing the drive list to never populate.

Signed-off-by: Brandon O'Hare <brandon.ohare@seagate.com>