### PR TITLE
Feature/foss 426 drive constants update

### DIFF
--- a/doc/lvm_propeller_test.md
+++ b/doc/lvm_propeller_test.md
@@ -10,6 +10,7 @@ automatic mode using **pytest** (or **py.test**).
 
 ## Test setup
 
+### Environment
 Before running any test cases, you will need to configure the environment.
 Whether you are using manua; or automatic testing,
 this will configure the environment variables:
@@ -24,6 +25,7 @@ execute testing, you will need to run 'source init_env.sh' separately in both sh
 Two shell windows are useful for debugging the IDM lock
 manager daemon with one for the lock manager and another for the client.
 
+### Daemon
 For manual testing, we can use the below command to launch the daemon:
 
     $ ./src/seagate_ilm -D 1 -l 0 -L 7 -E 7 -S 7
@@ -47,6 +49,20 @@ The IDM locking manager has several options that can be modified:
 The above command manually launches IDM lock manager, specifying the following
 arguments: 'enabling debugging mode, without lockdown virtual addressing, log file
 priority is 7, stderr log priority is 7, and syslog log priority is 7'.
+
+### Unit test settings
+Currently, there are 2 files that have variable settings used throughout the unit test code.
+    - test/test_conf.h
+    - test/test_conf.py
+
+These 2 files are configuration settings used throughout the C code and the Python
+code, respectively.  (Note: These settings need to be refactored into a single JSON file)
+
+The most important settings to configure are the block device (BLK_DEVICEX) and
+scsi generic device (SG_DEVICEX) system paths.
+Make sure that these constant configuration settings are correct before running any
+unit tests.  Other drives on the system can be damaged if these setting are not configured
+correctly.
 
 ## Test examples
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (C) 2019 Red Hat, Inc.
-# Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+# Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
 # Derived from the sanlock file of the same name.
 
-
+import logging
 import os
 
 import pytest
@@ -11,55 +11,24 @@ import pytest
 from . import ilm_util
 
 import idm_scsi
+from test_conf import *     # Normally bad practice, but only importing 'constants' here
 
-DRIVE1 = "/dev/sg1"
-DRIVE2 = "/dev/sg2"
-DRIVE3 = "/dev/sg5"
-DRIVE4 = "/dev/sg7"
-DRIVE5 = "/dev/sg10"
-DRIVE6 = "/dev/sg11"
-DRIVE7 = "/dev/sg13"
-DRIVE8 = "/dev/sg14"
+_logger = logging.getLogger(__name__)
+
+BLK_DEVICES = [BLK_DEVICE1,
+               BLK_DEVICE2,
+               BLK_DEVICE3,
+               BLK_DEVICE4,
+               BLK_DEVICE5,
+               BLK_DEVICE6,
+               BLK_DEVICE7,
+               BLK_DEVICE8]
 
 @pytest.fixture(scope="session")
 def ilm_daemon():
-    lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
+    _logger.info('ilm_daemon start')
 
-    cmd = 'dd if=/dev/zero of=zero.bin count=1 bs=512' 
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE1 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE2 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE3 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE4 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE5 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE6 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE7 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE8 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE1);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE2);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE3);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE4);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE5);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE6);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE7);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE8);
+    _init_devices()
 
     """
     Run ILM daemon during a test.
@@ -69,49 +38,36 @@ def ilm_daemon():
         ilm_util.wait_for_daemon(0.5)
         yield
     finally:
-        # Killing lock manager allows terminating without reomving the lockspace.
+        # Killing lock manager allows terminating without removing the lockspace.
         p.kill()
         p.wait()
 
 @pytest.fixture(scope="session")
 def idm_cleanup():
-    lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
+    _logger.info('idm_cleanup start')
 
-    cmd = 'dd if=/dev/zero of=zero.bin count=1 bs=512' 
-    os.system(cmd)
+    _init_devices()
 
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE1 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
+def _init_devices():
+    LOCK_ID0 ='0000000000000000000000000000000000000000000000000000000000000000'
+    SG_CMD   = 'sg_raw -v -s 512 -i zero.bin'
+    SG_DATA  = 'F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
 
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE2 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
+    os.system('dd if=/dev/zero of=zero.bin count=1 bs=512')
 
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE3 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
+    for device in BLK_DEVICES:
+        try:
+            os.system(f'{SG_CMD} {device} {SG_DATA}')
+        except Exception as e:
+            _logger.error(f'{device} sg_raw failure')
+            raise e from None
 
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE4 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE5 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE6 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE7 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    cmd = 'sg_raw -v -s 512 -i zero.bin ' + DRIVE8 + ' F0 00 00 00 00 00 00 00 00 00 00 00 02 00 FF 00'
-    os.system(cmd)
-
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE1);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE2);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE3);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE4);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE5);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE6);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE7);
-    idm_scsi.idm_drive_lock_mode(lock_id0, DRIVE8);
+    for device in BLK_DEVICES:
+        try:
+            idm_scsi.idm_drive_lock_mode(LOCK_ID0, device)
+        except Exception as e:
+            _logger.error(f'{device} lock failure')
+            raise e from None
 
 def pytest_addoption(parser):
     parser.addoption('--run-destroy', action='store_true', dest="destroy",

--- a/test/idm_scsi_async_test.py
+++ b/test/idm_scsi_async_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-only
-# Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+# Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
 
 
 import errno
@@ -12,9 +12,7 @@ import select
 import pytest
 
 import idm_scsi
-
-DRIVE1 = "/dev/sg1"
-DRIVE2 = "/dev/sg2"
+from test_conf import *     # Normally bad practice, but only importing 'constants' here
 
 def wait_for_scsi_response(handle):
     sg_fd = idm_scsi.idm_drive_get_fd(handle)
@@ -37,7 +35,7 @@ def test_idm__async_lock_exclusive(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
     assert handle != 0
 
@@ -58,7 +56,7 @@ def test_idm__async_lock_exclusive(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -73,7 +71,7 @@ def test_idm__async_lock_shareable(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
     assert handle != 0
 
@@ -94,7 +92,7 @@ def test_idm__async_lock_shareable(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -109,11 +107,11 @@ def test_idm__async_lock_exclusive_two_drives(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                 host_id0, DRIVE1, 10000);
+                                                 host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                 host_id0, DRIVE2, 10000);
+                                                 host_id0, SG_DEVICE2, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -138,11 +136,11 @@ def test_idm__async_lock_exclusive_two_drives(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                   host_id0, a, 8, DRIVE2)
+                                                   host_id0, a, 8, SG_DEVICE2)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -162,11 +160,11 @@ def test_idm__async_lock_shareable_two_drives(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id0, DRIVE1, 10000);
+                                                 host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id0, DRIVE2, 10000);
+                                                 host_id0, SG_DEVICE2, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -191,11 +189,11 @@ def test_idm__async_lock_shareable_two_drives(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE2)
+                                                   host_id0, a, 8, SG_DEVICE2)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -216,11 +214,11 @@ def test_idm__async_lock_shareable_two_locks(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id0, DRIVE1, 10000);
+                                                 host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id1, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id0, DRIVE1, 10000);
+                                                 host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -245,11 +243,11 @@ def test_idm__async_lock_shareable_two_locks(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id1, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -270,11 +268,11 @@ def test_idm__async_break_lock_1(idm_cleanup):
     host_id1 = "00000000000000000000000000000001"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                 host_id0, DRIVE1, 5000);
+                                                 host_id0, SG_DEVICE1, 5000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                 host_id1, DRIVE1, 5000);
+                                                 host_id1, SG_DEVICE1, 5000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -291,7 +289,7 @@ def test_idm__async_break_lock_1(idm_cleanup):
     time.sleep(7)
 
     ret, handle = idm_scsi.idm_drive_break_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                      host_id1, DRIVE1, 5000);
+                                                      host_id1, SG_DEVICE1, 5000)
     assert ret == 0         # Break successfully
 
     wait_for_scsi_response(handle)
@@ -311,11 +309,11 @@ def test_idm__async_break_lock_1(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                   host_id1, a, 8, DRIVE1)
+                                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -336,11 +334,11 @@ def test_idm__async_break_lock_2(idm_cleanup):
     host_id1 = "00000000000000000000000000000001"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                 host_id0, DRIVE1, 5000);
+                                                 host_id0, SG_DEVICE1, 5000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id1, DRIVE1, 5000);
+                                                 host_id1, SG_DEVICE1, 5000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -357,7 +355,7 @@ def test_idm__async_break_lock_2(idm_cleanup):
     time.sleep(7)
 
     ret, handle = idm_scsi.idm_drive_break_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                      host_id1, DRIVE1, 5000);
+                                                      host_id1, SG_DEVICE1, 5000)
     assert ret == 0         # Break successfully
 
     wait_for_scsi_response(handle)
@@ -377,11 +375,11 @@ def test_idm__async_break_lock_2(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id1, a, 8, DRIVE1)
+                                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -402,11 +400,11 @@ def test_idm__async_break_lock_3(idm_cleanup):
     host_id1 = "00000000000000000000000000000001"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id0, DRIVE1, 5000);
+                                                 host_id0, SG_DEVICE1, 5000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                 host_id1, DRIVE1, 5000);
+                                                 host_id1, SG_DEVICE1, 5000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -423,7 +421,7 @@ def test_idm__async_break_lock_3(idm_cleanup):
     time.sleep(7)
 
     ret, handle = idm_scsi.idm_drive_break_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                      host_id1, DRIVE1, 5000);
+                                                      host_id1, SG_DEVICE1, 5000)
     assert ret == 0         # Break successfully
 
     wait_for_scsi_response(handle)
@@ -443,11 +441,11 @@ def test_idm__async_break_lock_3(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id1, a, 8, DRIVE1)
+                                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -467,7 +465,7 @@ def test_idm__async_convert_1(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -477,7 +475,7 @@ def test_idm__async_convert_1(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_convert_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -497,7 +495,7 @@ def test_idm__async_convert_1(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -512,7 +510,7 @@ def test_idm__async_convert_2(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -522,7 +520,7 @@ def test_idm__async_convert_2(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_convert_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -542,7 +540,7 @@ def test_idm__async_convert_2(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -558,11 +556,11 @@ def test_idm__async_convert_3(idm_cleanup):
     host_id1 = "00000000000000000000000000000001"
 
     ret, handle1 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id0, DRIVE1, 10000);
+                                                 host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                 host_id1, DRIVE1, 10000);
+                                                 host_id1, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -577,7 +575,7 @@ def test_idm__async_convert_3(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_convert_lock_async(lock_id0,
-		    idm_scsi.IDM_MODE_EXCLUSIVE, host_id1, DRIVE1, 10000);
+		    idm_scsi.IDM_MODE_EXCLUSIVE, host_id1, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -597,11 +595,11 @@ def test_idm__async_convert_3(idm_cleanup):
     a[7] = 0
 
     ret, handle1 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id0, a, 8, DRIVE1)
+                                                   host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     ret, handle2 = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                   host_id1, a, 8, DRIVE1)
+                                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle1)
@@ -621,7 +619,7 @@ def test_idm__async_renew_1(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -633,7 +631,7 @@ def test_idm__async_renew_1(idm_cleanup):
     time.sleep(5)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -645,7 +643,7 @@ def test_idm__async_renew_1(idm_cleanup):
     time.sleep(5)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -657,7 +655,7 @@ def test_idm__async_renew_1(idm_cleanup):
     time.sleep(5)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, SG_DEVICE1, 10000);
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -677,7 +675,7 @@ def test_idm__async_renew_1(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -692,7 +690,7 @@ def test_idm__async_renew_2(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -704,7 +702,7 @@ def test_idm__async_renew_2(idm_cleanup):
     time.sleep(5)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -716,7 +714,7 @@ def test_idm__async_renew_2(idm_cleanup):
     time.sleep(5)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -728,7 +726,7 @@ def test_idm__async_renew_2(idm_cleanup):
     time.sleep(5)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -748,7 +746,7 @@ def test_idm__async_renew_2(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -763,7 +761,7 @@ def test_idm__async_renew_timout_1(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -775,7 +773,7 @@ def test_idm__async_renew_timout_1(idm_cleanup):
     time.sleep(7)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_SHAREABLE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -795,7 +793,7 @@ def test_idm__async_renew_timout_1(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -810,7 +808,7 @@ def test_idm__async_renew_timeout_2(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -822,7 +820,7 @@ def test_idm__async_renew_timeout_2(idm_cleanup):
     time.sleep(7)
 
     ret, handle = idm_scsi.idm_drive_renew_lock_async(lock_id0,
-                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, DRIVE1, 10000);
+                        idm_scsi.IDM_MODE_EXCLUSIVE, host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -842,7 +840,7 @@ def test_idm__async_renew_timeout_2(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -857,7 +855,7 @@ def test_idm__async_read_lvb_1(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -868,7 +866,7 @@ def test_idm__async_read_lvb_1(idm_cleanup):
 
     a = idm_scsi.charArray(8)
 
-    ret, handle = idm_scsi.idm_drive_read_lvb_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_read_lvb_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -887,7 +885,7 @@ def test_idm__async_read_lvb_1(idm_cleanup):
     assert ord(a[7]) == 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -902,7 +900,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -913,7 +911,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
 
     a = idm_scsi.charArray(8)
 
-    ret, handle = idm_scsi.idm_drive_read_lvb_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_read_lvb_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -941,7 +939,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
     a[7] = 'h'
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -951,7 +949,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -960,7 +958,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_read_lvb_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_read_lvb_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -979,7 +977,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
     assert ord(a[7]) == 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -994,7 +992,7 @@ def test_idm__async_get_host_count(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1003,12 +1001,12 @@ def test_idm__async_get_host_count(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 0
@@ -1025,7 +1023,7 @@ def test_idm__async_get_host_count(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1034,12 +1032,12 @@ def test_idm__async_get_host_count(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 0
@@ -1053,7 +1051,7 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     host_id2 = "00000000000000000000000000000002"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1063,7 +1061,7 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id1, DRIVE1, 10000);
+                                                host_id1, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1072,34 +1070,34 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 1
     assert self == 1
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id1, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id1, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 1
     assert self == 1
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id2, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id2, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 2
@@ -1116,7 +1114,7 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1126,7 +1124,7 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id1, a, 8, DRIVE1)
+                                                  host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1135,12 +1133,12 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 0
@@ -1154,7 +1152,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     host_id2 = "00000000000000000000000000000002"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1164,7 +1162,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id1, DRIVE1, 10000);
+                                                host_id1, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1174,7 +1172,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id2, DRIVE1, 10000);
+                                                host_id2, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1183,34 +1181,34 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 2
     assert self == 1
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id1, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id1, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 2
     assert self == 1
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id2, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id2, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 2
@@ -1227,7 +1225,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1237,7 +1235,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id1, a, 8, DRIVE1)
+                                                  host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1247,7 +1245,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert result == 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id2, a, 8, DRIVE1)
+                                                  host_id2, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1256,12 +1254,12 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_count_async(lock_id0, host_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
 
-    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle);
+    ret, count, self, result = idm_scsi.idm_drive_lock_count_async_result(handle)
     assert ret == 0
     assert result == 0
     assert count == 0
@@ -1272,7 +1270,7 @@ def test_idm__async_get_lock_mode(idm_cleanup):
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
 
-    ret, handle = idm_scsi.idm_drive_lock_mode_async(lock_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_mode_async(lock_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1288,7 +1286,7 @@ def test_idm__async_get_lock_exclusive_mode(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1297,7 +1295,7 @@ def test_idm__async_get_lock_exclusive_mode(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_mode_async(lock_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_mode_async(lock_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1318,7 +1316,7 @@ def test_idm__async_get_lock_exclusive_mode(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_EXCLUSIVE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1333,7 +1331,7 @@ def test_idm__async_get_lock_shareable_mode(idm_cleanup):
     host_id0 = "00000000000000000000000000000000"
 
     ret, handle = idm_scsi.idm_drive_lock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                host_id0, DRIVE1, 10000);
+                                                host_id0, SG_DEVICE1, 10000)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1342,7 +1340,7 @@ def test_idm__async_get_lock_shareable_mode(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-    ret, handle = idm_scsi.idm_drive_lock_mode_async(lock_id0, DRIVE1);
+    ret, handle = idm_scsi.idm_drive_lock_mode_async(lock_id0, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)
@@ -1363,7 +1361,7 @@ def test_idm__async_get_lock_shareable_mode(idm_cleanup):
     a[7] = 0
 
     ret, handle = idm_scsi.idm_drive_unlock_async(lock_id0, idm_scsi.IDM_MODE_SHAREABLE,
-                                                  host_id0, a, 8, DRIVE1)
+                                                  host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
     wait_for_scsi_response(handle)

--- a/test/ilm_inject_fault_test.py
+++ b/test/ilm_inject_fault_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-only
-# Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+# Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
 
 
 import errno
@@ -11,18 +11,7 @@ import uuid
 import pytest
 
 import ilm
-
-DRIVE1 = "/dev/sdb2"
-DRIVE2 = "/dev/sdc2"
-DRIVE3 = "/dev/sdb3"
-DRIVE4 = "/dev/sdc3"
-
-LOCK1_VG_UUID = "00000000000000000000000000000001"
-LOCK1_LV_UUID = "0123456789abcdef0123456789abcdef"
-
-HOST1 = "00000000000000000000000000000000"
-HOST2 = "00000000000000000000000000000001"
-HOST3 = "00000000000000000000000000000002"
+from test_conf import *     # Normally bad practice, but only importing 'constants' here
 
 def test_inject_fault__2_drives_lock(ilm_daemon):
     ret, s = ilm.ilm_connect()
@@ -36,8 +25,8 @@ def test_inject_fault__2_drives_lock(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_inject_fault(s, 100)
@@ -76,9 +65,9 @@ def test_inject_fault__3_drives_lock(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_inject_fault(s, 100)
@@ -138,10 +127,10 @@ def test_inject_fault__4_drives_lock(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_inject_fault(s, 100)
@@ -195,8 +184,8 @@ def test_inject_fault__2_drives_unlock(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -233,9 +222,9 @@ def test_inject_fault__3_drives_unlock(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -283,10 +272,10 @@ def test_inject_fault__4_drives_unlock(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -340,8 +329,8 @@ def test_inject_fault__2_drives_convert(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -383,9 +372,9 @@ def test_inject_fault__3_drives_convert(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -427,10 +416,10 @@ def test_inject_fault__4_drives_convert(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -472,7 +461,7 @@ def test_inject_fault_100_percent__1_drive_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 1
-    lock_op.set_drive_names(0, DRIVE1)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -508,7 +497,7 @@ def test_inject_fault_50_percent__1_drive_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 1
-    lock_op.set_drive_names(0, DRIVE1)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -544,7 +533,7 @@ def test_inject_fault_10_percent__1_drive_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 1
-    lock_op.set_drive_names(0, DRIVE1)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -579,7 +568,7 @@ def test_inject_fault__1_drive_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 1
-    lock_op.set_drive_names(0, DRIVE1)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ## Test for 100 percentage fault
@@ -659,8 +648,8 @@ def test_inject_fault_100_percent__2_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -696,8 +685,8 @@ def test_inject_fault_50_percent__2_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -733,8 +722,8 @@ def test_inject_fault_10_percent__2_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -769,8 +758,8 @@ def test_inject_fault__2_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ## Test for 100 percentage fault
@@ -850,9 +839,9 @@ def test_inject_fault_100_percent__3_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -888,9 +877,9 @@ def test_inject_fault_50_percent__3_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -926,9 +915,9 @@ def test_inject_fault_10_percent__3_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -963,9 +952,9 @@ def test_inject_fault__3_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 3
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ## Test for 100 percentage fault
@@ -1045,10 +1034,10 @@ def test_inject_fault_100_percent__4_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1084,10 +1073,10 @@ def test_inject_fault_50_percent__4_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1123,10 +1112,10 @@ def test_inject_fault_10_percent__4_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1161,10 +1150,10 @@ def test_inject_fault__4_drives_renew(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 4
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
-    lock_op.set_drive_names(2, DRIVE3)
-    lock_op.set_drive_names(3, DRIVE4)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
+    lock_op.set_drive_names(2, BLK_DEVICE3)
+    lock_op.set_drive_names(3, BLK_DEVICE4)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ## Test for 100 percentage fault

--- a/test/ilm_lvb_test.py
+++ b/test/ilm_lvb_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-only
-# Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+# Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
 
 
 import errno
@@ -11,16 +11,7 @@ import uuid
 import pytest
 
 import ilm
-
-DRIVE1 = "/dev/sdb3"
-DRIVE2 = "/dev/sdc3"
-
-LOCK1_VG_UUID = "00000000000000000000000000000001"
-LOCK1_LV_UUID = "0123456789abcdef0123456789abcdef"
-
-HOST1 = "00000000000000000000000000000000"
-HOST2 = "00000000000000000000000000000001"
-HOST3 = "00000000000000000000000000000002"
+from test_conf import *     # Normally bad practice, but only importing 'constants' here
 
 def test_lock__lvb_read(ilm_daemon):
     ret, s = ilm.ilm_connect()
@@ -34,8 +25,8 @@ def test_lock__lvb_read(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -43,7 +34,7 @@ def test_lock__lvb_read(ilm_daemon):
 
     a = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s, lock_id, a, 8)
     assert ret == 0
     assert ord(a[0]) == 0
     assert ord(a[1]) == 0
@@ -82,8 +73,8 @@ def test_lock__lvb_read_two_hosts(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -91,7 +82,7 @@ def test_lock__lvb_read_two_hosts(ilm_daemon):
 
     a = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s1, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s1, lock_id, a, 8)
     assert ret == 0
     assert ord(a[0]) == 0
     assert ord(a[1]) == 0
@@ -111,7 +102,7 @@ def test_lock__lvb_read_two_hosts(ilm_daemon):
     a[6] = 'g'
     a[7] = 'h'
 
-    ret = ilm.ilm_write_lvb(s1, lock_id, a, 8);
+    ret = ilm.ilm_write_lvb(s1, lock_id, a, 8)
     assert ret == 0
 
     ret = ilm.ilm_unlock(s1, lock_id)
@@ -132,7 +123,7 @@ def test_lock__lvb_read_two_hosts(ilm_daemon):
 
     b = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s1, lock_id, b, 8);
+    ret = ilm.ilm_read_lvb(s1, lock_id, b, 8)
     assert ret == 0
     assert b[0] == 'a'
     assert b[1] == 'b'
@@ -151,7 +142,7 @@ def test_lock__lvb_read_two_hosts(ilm_daemon):
 
     c = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s2, lock_id, c, 8);
+    ret = ilm.ilm_read_lvb(s2, lock_id, c, 8)
     assert ret == 0
     assert c[0] == 'a'
     assert c[1] == 'b'
@@ -183,8 +174,8 @@ def test_lock__lvb_write(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -192,11 +183,11 @@ def test_lock__lvb_write(ilm_daemon):
 
     a = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s, lock_id, a, 8)
     assert ret == 0
 
     a[0] = 'a'
-    ret = ilm.ilm_write_lvb(s, lock_id, a, 8);
+    ret = ilm.ilm_write_lvb(s, lock_id, a, 8)
     assert ret == 0
 
     ret = ilm.ilm_unlock(s, lock_id)
@@ -206,7 +197,7 @@ def test_lock__lvb_write(ilm_daemon):
     assert ret == 0
 
     a[0] = '0'
-    ret = ilm.ilm_read_lvb(s, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s, lock_id, a, 8)
     assert ret == 0
     assert a[0] == 'a'
 
@@ -238,8 +229,8 @@ def test_lock__lvb_write_two_hosts(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -247,7 +238,7 @@ def test_lock__lvb_write_two_hosts(ilm_daemon):
 
     a = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s1, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s1, lock_id, a, 8)
     assert ret == 0
 
     a[0] = 'a'
@@ -259,7 +250,7 @@ def test_lock__lvb_write_two_hosts(ilm_daemon):
     a[6] = 'g'
     a[7] = 'h'
 
-    ret = ilm.ilm_write_lvb(s1, lock_id, a, 8);
+    ret = ilm.ilm_write_lvb(s1, lock_id, a, 8)
     assert ret == 0
 
     ret = ilm.ilm_unlock(s1, lock_id)
@@ -270,7 +261,7 @@ def test_lock__lvb_write_two_hosts(ilm_daemon):
 
     b = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s2, lock_id, b, 8);
+    ret = ilm.ilm_read_lvb(s2, lock_id, b, 8)
     assert ret == 0
     assert b[0] == 'a'
     assert b[1] == 'b'
@@ -290,7 +281,7 @@ def test_lock__lvb_write_two_hosts(ilm_daemon):
     b[6] = 'U'
     b[7] = 'U'
 
-    ret = ilm.ilm_write_lvb(s2, lock_id, b, 8);
+    ret = ilm.ilm_write_lvb(s2, lock_id, b, 8)
     assert ret == 0
 
     ret = ilm.ilm_unlock(s2, lock_id)
@@ -299,7 +290,7 @@ def test_lock__lvb_write_two_hosts(ilm_daemon):
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
     assert ret == 0
 
-    ret = ilm.ilm_read_lvb(s1, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s1, lock_id, a, 8)
     assert ret == 0
     assert a[0] == 'U'
     assert a[1] == 'U'
@@ -341,8 +332,8 @@ def test_lock__lvb_read_timeout(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 5000     # Timeout: 5s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -358,7 +349,7 @@ def test_lock__lvb_read_timeout(ilm_daemon):
 
     a = ilm.charArray(8)
 
-    ret = ilm.ilm_read_lvb(s2, lock_id, a, 8);
+    ret = ilm.ilm_read_lvb(s2, lock_id, a, 8)
 
     assert ret == 0
     assert a[0] == '\udcff'

--- a/test/ilm_test.py
+++ b/test/ilm_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-only
-# Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+# Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
 
 
 import errno
@@ -11,19 +11,7 @@ import uuid
 import pytest
 
 import ilm
-
-DRIVE1 = "/dev/sdb3"
-DRIVE2 = "/dev/sdc3"
-
-LOCK1_VG_UUID = "00000000000000000000000000000001"
-LOCK1_LV_UUID = "0123456789abcdef0123456789abcdef"
-
-LOCK2_VG_UUID = "00000000000000000000000000000002"
-LOCK2_LV_UUID = "0123456789abcdef1111111111111111"
-
-HOST1 = "00000000000000000000000000000000"
-HOST2 = "00000000000000000000000000000001"
-HOST3 = "00000000000000000000000000000002"
+from test_conf import *     # Normally bad practice, but only importing 'constants' here
 
 def test_lockspace(ilm_daemon):
     ret, s = ilm.ilm_connect()
@@ -38,7 +26,7 @@ def test_version(ilm_daemon):
     assert ret == 0
     assert s > 0
 
-    ret, version = ilm.ilm_version(s, DRIVE1)
+    ret, version = ilm.ilm_version(s, BLK_DEVICE1)
     assert ret == 0
     assert version == 0x100
 
@@ -57,8 +45,8 @@ def test_lock__shareable_smoke_test(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -83,8 +71,8 @@ def test_lock__shareable_100_times(ilm_daemon):
         lock_op = ilm.idm_lock_op()
         lock_op.mode = ilm.IDM_MODE_SHAREABLE
         lock_op.drive_num = 2
-        lock_op.set_drive_names(0, DRIVE1)
-        lock_op.set_drive_names(1, DRIVE2)
+        lock_op.set_drive_names(0, BLK_DEVICE1)
+        lock_op.set_drive_names(1, BLK_DEVICE2)
         lock_op.timeout = 60000     # Timeout: 60s
 
         ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -108,8 +96,8 @@ def test_lock__exclusive_smoke_test(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -134,8 +122,8 @@ def test_lock__exclusive_100_times(ilm_daemon):
         lock_op = ilm.idm_lock_op()
         lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
         lock_op.drive_num = 2
-        lock_op.set_drive_names(0, DRIVE1)
-        lock_op.set_drive_names(1, DRIVE2)
+        lock_op.set_drive_names(0, BLK_DEVICE1)
+        lock_op.set_drive_names(1, BLK_DEVICE2)
         lock_op.timeout = 60000     # Timeout: 60s
 
         ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -159,8 +147,8 @@ def test_lock__wrong_mode(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = 0
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -181,8 +169,8 @@ def test_lock__one_host_exclusive_twice(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -209,8 +197,8 @@ def test_lock__one_host_shareable_twice(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -237,8 +225,8 @@ def test_lock__one_host_release_twice(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -275,8 +263,8 @@ def test_lock__two_hosts_exclusive_success_exclusive_fail(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -317,8 +305,8 @@ def test_lock__two_hosts_shareable_success_shareable_success(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -361,8 +349,8 @@ def test_lock__two_hosts_shareable_success_exclusive_fail(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -371,8 +359,8 @@ def test_lock__two_hosts_shareable_success_exclusive_fail(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s2, lock_id, lock_op)
@@ -412,8 +400,8 @@ def test_lock__two_hosts_exclusive_success_shareable_fail(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -422,8 +410,8 @@ def test_lock__two_hosts_exclusive_success_shareable_fail(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s2, lock_id, lock_op)
@@ -463,8 +451,8 @@ def test_lock__two_hosts_exclusive_wrong_release_ahead(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -504,8 +492,8 @@ def test_lock__two_hosts_exclusive_wrong_release_after(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -535,8 +523,8 @@ def test_lock__convert_shareable_to_shareable(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -563,8 +551,8 @@ def test_lock__convert_shareable_to_exclusive(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -591,8 +579,8 @@ def test_lock__convert_exclusive_to_shareable(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -619,8 +607,8 @@ def test_lock__convert_exclusive_to_exclusive(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -657,8 +645,8 @@ def test_lock__two_hosts_convert_shareable_to_exclusive(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -707,8 +695,8 @@ def test_lock__two_hosts_convert_shareable_to_exclusive_success(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -757,8 +745,8 @@ def test_lock__two_hosts_convert_shareable_timeout_to_exclusive_success(ilm_daem
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 20000     # Timeout: 20s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -817,8 +805,8 @@ def test_lock__two_hosts_convert_shareable_timeout_to_shareable_success(ilm_daem
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 20000     # Timeout: 20s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -880,8 +868,8 @@ def test_lock__two_hosts_convert_exclusive_timeout_to_exclusive_success(ilm_daem
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 20000     # Timeout: 20s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -933,8 +921,8 @@ def test_lock__two_hosts_convert_exclusive_timeout_to_shareable_success(ilm_daem
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_EXCLUSIVE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 20000     # Timeout: 20s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -975,8 +963,8 @@ def test_lock__timeout(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1006,8 +994,8 @@ def test_lock__timeout_convert1(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1041,8 +1029,8 @@ def test_lock__timeout_convert2(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 3s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1081,8 +1069,8 @@ def test_lock__get_mode(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1116,8 +1104,8 @@ def test_lock__get_mode_not_existed(ilm_daemon):
 
     lock_op = ilm.idm_lock_op()
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     # Return unlock mode if the IDM has not been created
@@ -1150,8 +1138,8 @@ def test_lock__two_hosts_get_mode(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -1202,8 +1190,8 @@ def test_lock__get_host_count(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s, lock_id, lock_op)
@@ -1247,8 +1235,8 @@ def test_lock__two_hosts_get_host_count(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -1316,8 +1304,8 @@ def test_lock__three_hosts_get_host_count(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 60000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)
@@ -1411,8 +1399,8 @@ def test_lock__destroy(ilm_daemon):
     lock_op = ilm.idm_lock_op()
     lock_op.mode = ilm.IDM_MODE_SHAREABLE
     lock_op.drive_num = 2
-    lock_op.set_drive_names(0, DRIVE1)
-    lock_op.set_drive_names(1, DRIVE2)
+    lock_op.set_drive_names(0, BLK_DEVICE1)
+    lock_op.set_drive_names(1, BLK_DEVICE2)
     lock_op.timeout = 3000     # Timeout: 60s
 
     ret = ilm.ilm_lock(s1, lock_id, lock_op)

--- a/test/killpath_test.c
+++ b/test/killpath_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
- * Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
  */
 
 #include <errno.h>
@@ -18,11 +18,9 @@
 #include <sys/types.h>
 
 #include <ilm.h>
+#include "test_conf.h"
 
 #define EVENT_BUF_LEN     (16)
-
-#define DRIVE1	"/dev/sdb2"
-#define DRIVE2	"/dev/sdd2"
 
 static int wait_for_notify(void)
 {
@@ -96,8 +94,8 @@ int main(void)
 
 	lock_op.mode = IDM_MODE_EXCLUSIVE;
 	lock_op.drive_num = 2;
-	lock_op.drives[0] = DRIVE1;
-	lock_op.drives[1] = DRIVE2;
+	lock_op.drives[0] = BLK_DEVICE1;
+	lock_op.drives[1] = BLK_DEVICE2;
 
 	/* Set timeout to 3s */
 	lock_op.timeout = 3000;

--- a/test/killsignal_test.c
+++ b/test/killsignal_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
- * Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
  */
 
 #include <errno.h>
@@ -14,9 +14,7 @@
 #include <unistd.h>
 
 #include <ilm.h>
-
-#define DRIVE1	"/dev/sdb2"
-#define DRIVE2	"/dev/sdd2"
+#include "test_conf.h"
 
 static int signal_received = 0;
 
@@ -80,8 +78,8 @@ int main(void)
 
 	lock_op.mode = IDM_MODE_EXCLUSIVE;
 	lock_op.drive_num = 2;
-	lock_op.drives[0] = DRIVE1;
-	lock_op.drives[1] = DRIVE2;
+	lock_op.drives[0] = BLK_DEVICE1;
+	lock_op.drives[1] = BLK_DEVICE2;
 
 	/* Set timeout to 3s */
 	lock_op.timeout = 3000;

--- a/test/smoke_test.c
+++ b/test/smoke_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
- * Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
  */
 
 #include <stdio.h>
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include <ilm.h>
+#include "test_conf.h"
 
 int main(void)
 {
@@ -29,8 +30,8 @@ int main(void)
 
 	lock_op.mode = 1;
 	lock_op.drive_num = 2;
-	lock_op.drives[0] = "/dev/sda1";
-	lock_op.drives[1] = "/dev/sda2";
+	lock_op.drives[0] = BLK_DEVICE1;
+	lock_op.drives[1] = BLK_DEVICE2;
 	lock_op.timeout = 3000;
 
 	ret = ilm_lock(s, &lock_id, &lock_op);

--- a/test/stress_test.c
+++ b/test/stress_test.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
- * Copyright (C) 2021 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
  */
 
 #include <pthread.h>
@@ -13,14 +13,10 @@
 #include <string.h>
 
 #include <ilm.h>
+#include "test_conf.h"
 
 struct idm_lock_id lock_id;
 int need_exit = 0;
-
-#define DRIVE1	"/dev/sdb2"
-#define DRIVE2	"/dev/sdd2"
-#define DRIVE3	"/dev/sde2"
-#define DRIVE4	"/dev/sdg2"
 
 static void *test_thread(void *data)
 {
@@ -49,10 +45,10 @@ static void *test_thread(void *data)
 
 		lock_op.mode = IDM_MODE_EXCLUSIVE;
 		lock_op.drive_num = 4;
-		lock_op.drives[0] = DRIVE1;
-		lock_op.drives[1] = DRIVE2;
-		lock_op.drives[2] = DRIVE3;
-		lock_op.drives[3] = DRIVE4;
+		lock_op.drives[0] = BLK_DEVICE1;
+		lock_op.drives[1] = BLK_DEVICE2;
+		lock_op.drives[2] = BLK_DEVICE3;
+		lock_op.drives[3] = BLK_DEVICE4;
 		lock_op.timeout = 3000;
 
 		ret = ilm_lock(s, &lock_id, &lock_op);

--- a/test/test_conf.h
+++ b/test/test_conf.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+/* Device path config settings for all *.c unit test files.
+/*
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ */
+
+//TODO: Consolidate these settings, along with the duplicate python settings, in a .json file
+#define BLK_DEVICE1 "/dev/sdb2"
+#define BLK_DEVICE2 "/dev/sdc2"
+#define BLK_DEVICE3 "/dev/sdd"
+#define BLK_DEVICE4 "/dev/sde"
+#define BLK_DEVICE5 "/dev/sdf"
+#define BLK_DEVICE6 "/dev/sdg"
+#define BLK_DEVICE7 "/dev/sdh"
+#define BLK_DEVICE8 "/dev/sdi"

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+# Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+
+
+#TODO: Consolidate these settings, along with the duplicate c-code settings, in a .json file
+BLK_DEVICE1 = '/dev/sdb2'
+BLK_DEVICE2 = '/dev/sdc2'
+BLK_DEVICE3 = '/dev/sdd'
+BLK_DEVICE4 = '/dev/sde'
+BLK_DEVICE5 = '/dev/sdf'
+BLK_DEVICE6 = '/dev/sdg'
+BLK_DEVICE7 = '/dev/sdh'
+BLK_DEVICE8 = '/dev/sdi'
+
+SG_DEVICE1 = '/dev/sg1'
+SG_DEVICE2 = '/dev/sg2'
+SG_DEVICE3 = '/dev/sg3'
+SG_DEVICE4 = '/dev/sg4'
+SG_DEVICE5 = '/dev/sg5'
+SG_DEVICE6 = '/dev/sg6'
+SG_DEVICE7 = '/dev/sg7'
+SG_DEVICE8 = '/dev/sg8'
+
+LOCK1_VG_UUID = '00000000000000000000000000000001'
+LOCK1_LV_UUID = '0123456789abcdef0123456789abcdef'
+
+LOCK2_VG_UUID = '00000000000000000000000000000002'
+LOCK2_LV_UUID = '0123456789abcdef1111111111111111'
+
+HOST1 = '00000000000000000000000000000000'
+HOST2 = '00000000000000000000000000000001'
+HOST3 = '00000000000000000000000000000002'
+


### PR DESCRIPTION
Consolidate important system device path settings scattered throughout the unit test files into 2 files, 1 for each programming language currently used within the unit tests.
This is intended as a quick, interim solution that incrementally improves the code.  The correct way to solve this is to consolidate all these configuration setting within a single JSON file that is then used by all languages within the unit test code.  But that is beyond the scope of this ticket.
Note that some files with dozens of changes are just repetitious renaming of the configuration constants.  