### PR TITLE
FOSS-437: Add NVMe identify command

### DIFF
--- a/src/idm_nvme.c
+++ b/src/idm_nvme.c
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme.c - NVMe interface for In-drive Mutex (IDM)
+ */
+
+//IDM-specific
+#include <fcntl.h>
+#include <linux/nvme_ioctl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "idm_nvme.h"
+
+#define SUCCESS 0;
+#define FAILURE 1;  // Make -1??
+
+//TODO: Keep this (and the corresponding #ifdef's)???
+#define NVME_STANDALONE
+
+
+/**
+ * fill_cmd_identify - Setup the NVMe command struct Identify Controller (opcode=0x6)
+ * @admin_cmd:		        NVMe Admin Command struct to fill
+ * @data_identify_ctrl:		NVMe Admin Commmand data struct.  This is the cmd output destination.
+ *
+ */
+void fill_cmd_identify(struct nvme_admin_cmd *admin_cmd, nvmeIDCtrl *data_identify_ctrl) {
+
+    memset(admin_cmd,          0, sizeof(struct nvme_admin_cmd));
+    memset(data_identify_ctrl, 0, sizeof(nvmeIDCtrl));
+
+    admin_cmd->opcode     = NVME_ADMIN_CMD_IDENTIFY;
+    admin_cmd->addr       = C_CAST(uint64_t, C_CAST(uintptr_t, data_identify_ctrl));
+    admin_cmd->data_len   = NVME_IDENTIFY_DATA_LEN;
+    admin_cmd->cdw10      = NVME_IDENTIFY_CTRL;         // Set CNS
+    admin_cmd->timeout_ms = ADMIN_CMD_TIMEOUT_DEFAULT;
+}
+
+/**
+ * nvme_identify - Send NVMe Identify Controller command to specified device.
+ * @drive:		Drive path name.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int nvme_identify(char *drive) {
+
+    printf("%s: IN: drive=%s\n", __func__, drive);
+
+    struct nvme_admin_cmd admin_cmd;
+    nvmeIDCtrl data_identify_ctrl;
+    int ret = SUCCESS;
+
+
+//TODO: This should ALWAYS be 4096.  Make a compile check for this??
+    printf("sizeof(nvmeIDCtrl) = %d\n", sizeof(nvmeIDCtrl));
+
+    fill_cmd_identify(&admin_cmd, &data_identify_ctrl);
+
+    ret = send_nvme_admin_cmd(drive, &admin_cmd);
+
+    printf("%s: data_identify_ctrl.subnqn = %s\n", __func__, data_identify_ctrl.subnqn);
+
+    return ret;
+}
+
+/**
+ * send_nvme_admin_cmd - Send NVMe Admin command to specified device.
+ * @drive:		Drive path name.
+ * @admin_cmd:	NVMe Admin Command struct
+ *
+  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+*/
+int send_nvme_admin_cmd(char *drive, struct nvme_admin_cmd *admin_cmd) {
+
+    int nvme_fd;
+    int ret = SUCCESS;
+
+
+	if ((nvme_fd = open(drive, O_RDWR | O_NONBLOCK)) < 0) {
+        #ifndef NVME_STANDALONE
+		ilm_log_err("%s: error opening drive %s fd %d",
+			    __func__, drive, nvme_fd);
+        #else
+		printf("%s: error opening drive %s fd %d\n",
+			    __func__, drive, nvme_fd);
+        #endif
+		return nvme_fd;
+	}
+
+    ret = ioctl(nvme_fd, NVME_IOCTL_ADMIN_CMD, admin_cmd);
+    if(ret) {
+        #ifndef NVME_STANDALONE
+        ilm_log_err("%s: ioctl failed: %d", __func__, ret);
+        #else
+        printf("%s: ioctl failed: %d\n", __func__, ret);
+        #endif
+        goto out;
+    }
+
+//TODO: Keep this debug??
+    printf("%s: ioctl ret=%d\n", __func__, ret);
+    printf("%s: ioctl admin_cmd->result=%d\n", __func__, admin_cmd->result);
+
+//SIDE-NOTE:
+// dw0: admin_cmd->result
+// dw3: ret << 17
+
+out:
+    close(nvme_fd);
+    return ret;
+}
+
+
+
+
+
+
+
+/*#########################################################################################
+########################### STAND-ALONE MAIN ##############################################
+#########################################################################################*/
+#define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1";
+
+//To compile:
+//gcc idm_nvme.c -o idm_nvme
+int main(int argc, char *argv[])
+{
+    char *drive;
+
+    if(argc >= 3){
+        drive = argv[2];
+    }
+    else {
+        drive = DRIVE_DEFAULT_DEVICE;
+    }
+
+    if(argc >= 2){
+        if(strcmp(argv[1], "identify") == 0){
+            //cli usage: idm_nvme identify
+            nvme_identify(drive);
+        }
+
+    }
+
+
+    return 0;
+}

--- a/src/idm_nvme.h
+++ b/src/idm_nvme.h
@@ -1,0 +1,175 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme.h - NVMe interface for In-drive Mutex (IDM)
+ */
+
+#include <stdint.h>
+
+
+#define ADMIN_CMD_TIMEOUT_DEFAULT 15
+#define NVME_IDENTIFY_DATA_LEN    4096
+
+#define C_CAST(type, val) (type)(val)
+
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef enum _eNVMeAdminOpCodes {
+    // NVME_ADMIN_CMD_DELETE_SQ                    = 0x00,
+    // NVME_ADMIN_CMD_CREATE_SQ                    = 0x01,
+    // NVME_ADMIN_CMD_GET_LOG_PAGE                 = 0x02,
+    // NVME_ADMIN_CMD_DELETE_CQ                    = 0x04,
+    // NVME_ADMIN_CMD_CREATE_CQ                    = 0x05,
+    NVME_ADMIN_CMD_IDENTIFY                     = 0x06,
+    // NVME_ADMIN_CMD_ABORT_CMD                    = 0x08,
+    // NVME_ADMIN_CMD_SET_FEATURES                 = 0x09,
+    // NVME_ADMIN_CMD_GET_FEATURES                 = 0x0A,
+    // NVME_ADMIN_CMD_ASYNC_EVENT                  = 0x0C,
+    // NVME_ADMIN_CMD_NAMESPACE_MANAGEMENT         = 0x0D,
+    // NVME_ADMIN_CMD_ACTIVATE_FW                  = 0x10,
+    // NVME_ADMIN_CMD_DOWNLOAD_FW                  = 0x11,
+    // NVME_ADMIN_CMD_DEVICE_SELF_TEST             = 0x14,
+    // NVME_ADMIN_CMD_NAMESPACE_ATTACHMENT         = 0x15,
+    // NVME_ADMIN_CMD_KEEP_ALIVE                   = 0x18,
+    // NVME_ADMIN_CMD_DIRECTIVE_SEND               = 0x19,
+    // NVME_ADMIN_CMD_DIRECTIVE_RECEIVE            = 0x1A,
+    // NVME_ADMIN_CMD_VIRTUALIZATION_MANAGEMENT    = 0x1C,
+    // NVME_ADMIN_CMD_NVME_MI_SEND                 = 0x1D,
+    // NVME_ADMIN_CMD_NVME_MI_RECEIVE              = 0x1E,
+    // NVME_ADMIN_CMD_DOORBELL_BUFFER_CONFIG       = 0x7C,
+    // NVME_ADMIN_CMD_NVME_OVER_FABRICS            = 0x7F,
+    // NVME_ADMIN_CMD_FORMAT_NVM                   = 0x80,
+    // NVME_ADMIN_CMD_SECURITY_SEND                = 0x81,
+    // NVME_ADMIN_CMD_SECURITY_RECV                = 0x82,
+    // NVME_ADMIN_CMD_SANITIZE                     = 0x84,
+} eNVMeAdminOpCodes;
+
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef enum _eNvmeIdentifyCNS {
+    NVME_IDENTIFY_NS = 0,
+    NVME_IDENTIFY_CTRL = 1,
+    // NVME_IDENTIFY_ALL_ACTIVE_NS = 2,
+    // NVME_IDENTIFY_NS_ID_DESCRIPTOR_LIST = 3,
+} eNvmeIdentifyCNS;
+
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef struct _nvmeIDPowerState {
+    uint16_t            maxPower;   /* centiwatts */
+    uint8_t             rsvd2;
+    uint8_t             flags;
+    uint32_t            entryLat;   /* microseconds */
+    uint32_t            exitLat;    /* microseconds */
+    uint8_t             readTPut;
+    uint8_t             readLat;
+    uint8_t             writeLput;
+    uint8_t             writeLat;
+    uint16_t            idlePower;
+    uint8_t             idleScale;
+    uint8_t             rsvd19;
+    uint16_t            activePower;
+    uint8_t             activeWorkScale;
+    uint8_t             rsvd23[9];
+}nvmeIDPowerState;
+
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef struct _nvmeIDCtrl {
+    //controller capabilities and features
+    uint16_t            vid;
+    uint16_t            ssvid;
+    char                sn[20];
+    char                mn[40];
+    char                fr[8];
+    uint8_t             rab;
+    uint8_t             ieee[3];
+    uint8_t             cmic;
+    uint8_t             mdts;
+    uint16_t            cntlid;
+    uint32_t            ver;
+    uint32_t            rtd3r;
+    uint32_t            rtd3e;
+    uint32_t            oaes;
+    uint32_t            ctratt;
+    uint16_t            rrls;
+    uint8_t             reservedBytes110_102[9];
+    uint8_t             cntrltype;
+    uint8_t             fguid[16];//128bit identifier
+    uint16_t            crdt1;
+    uint16_t            crdt2;
+    uint16_t            crdt3;
+    uint8_t             reservedBytes239_134[106];
+    uint8_t             nvmManagement[16];
+    //Admin command set attribues & optional controller capabilities
+    uint16_t            oacs;
+    uint8_t             acl;
+    uint8_t             aerl;
+    uint8_t             frmw;
+    uint8_t             lpa;
+    uint8_t             elpe;
+    uint8_t             npss;
+    uint8_t             avscc;
+    uint8_t             apsta;
+    uint16_t            wctemp;
+    uint16_t            cctemp;
+    uint16_t            mtfa;
+    uint32_t            hmpre;
+    uint32_t            hmmin;
+    uint8_t             tnvmcap[16];
+    uint8_t             unvmcap[16];
+    uint32_t            rpmbs;
+    uint16_t            edstt;
+    uint8_t             dsto;
+    uint8_t             fwug;
+    uint16_t            kas;
+    uint16_t            hctma;
+    uint16_t            mntmt;
+    uint16_t            mxtmt;
+    uint32_t            sanicap;
+    uint32_t            hmminds;
+    uint16_t            hmmaxd;
+    uint16_t            nsetidmax;
+    uint16_t            endgidmax;
+    uint8_t             anatt;
+    uint8_t             anacap;
+    uint32_t            anagrpmax;
+    uint32_t            nanagrpid;
+    uint32_t            pels;
+    uint16_t            domainIdentifier;
+    uint8_t             reservedBytes367_358[10];
+    uint8_t             megcap[16];
+    uint8_t             reservedBytes511_384[128];
+    //NVM command set attributes;
+    uint8_t             sqes;
+    uint8_t             cqes;
+    uint16_t            maxcmd;
+    uint32_t            nn;
+    uint16_t            oncs;
+    uint16_t            fuses;
+    uint8_t             fna;
+    uint8_t             vwc;
+    uint16_t            awun;
+    uint16_t            awupf;
+    union {
+        uint8_t             nvscc;
+        uint8_t             icsvscc;
+    };
+    uint8_t             nwpc;
+    uint16_t            acwu;
+    uint16_t            optionalCopyFormatsSupported;
+    uint32_t            sgls;
+    uint32_t            mnan;
+    uint8_t             maxdna[16];
+    uint32_t            maxcna;
+    uint8_t             reservedBytes767_564[204];
+    char                subnqn[256];
+    uint8_t             reservedBytes1791_1024[768];
+    uint8_t             nvmeOverFabrics[256];
+    nvmeIDPowerState    psd[32];
+    uint8_t             vs[1024];
+}nvmeIDCtrl;
+
+
+void fill_cmd_identify(struct nvme_admin_cmd *admin_cmd, nvmeIDCtrl *data_identify_ctrl);
+int nvme_identify(char *drive);
+int send_nvme_admin_cmd(char *drive, struct nvme_admin_cmd *admin_cmd);
+


### PR DESCRIPTION
Add NVMe identify command.  
Uncertain if this'll be used by IDM.  
Mainly done as NVMe learning exercise. 
Added idm_nvme(.c\.h) files are being run stand-alone a the moment.