### PR TITLE
FOSS-449: Add IDM-specific write command

### DIFF
--- a/src/idm_nvme.h
+++ b/src/idm_nvme.h
@@ -348,8 +348,15 @@ void gen_nvme_cmd_idm_read(nvmeIdmVendorCmd *cmd_idm_read,
                            idmReadData *data_idm_read,
                            uint8_t idm_opcode,
                            uint8_t idm_group);
+void gen_nvme_cmd_idm_write(nvmeIdmVendorCmd *cmd_idm_write,
+                            idmWriteData *data_idm_write,
+                            uint8_t idm_opcode,
+                            uint8_t idm_group);
+
 int nvme_admin_identify(char *drive);
 int nvme_idm_read(char *drive, uint8_t idm_opcode, uint8_t idm_group);
+int nvme_idm_write(char *drive, uint8_t idm_opcode, uint8_t idm_group);
+
 int send_nvme_cmd_admin(char *drive, struct nvme_admin_cmd *cmd_admin);
 int send_nvme_cmd_idm(char *drive, nvmeIdmVendorCmd *cmd_idm_vendor);
 


### PR DESCRIPTION
Add IDM-specific write command (IDM read opcode 0xC1). Naming consistency across functions.

NOTE: Similar to the IDM read command of FOSS-448, this IDM write command is untested and is not fully functional.
This is my best guess for code based on the NVME and Propeller NVMe specs. I do think I'm close, though. The code is compiling and the read command can be called from the CLI and have ioctl() call into the kernel. However, it's currently failing with -1 since there is no Propeller NVMe firmware yet.

NOTE: Going forward this code will need to be heavily refactored.  Some of the data structures created at this lowest layer of code (that is interacting with the kernel via ioctl()) will actually need to come from a higher code layer.  This is fine for now, as one of the main purposes of this ticket was to learn the low-level details within the NVMe interface. 