### PR TITLE
Feature/foss 455 add nvme lock cmd

### DIFF
--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -62,6 +62,14 @@ typedef enum _eIdmResVer {
     IDM_RES_VER_INVALID            = 0x3,
 }eIdmResVer;
 
+// IDM Data char array lengths
+#define IDM_DATA_RESOURCE_VER_LEN_BYTES 8
+#define IDM_DATA_RESERVED_0_LEN_BYTES   24
+#define IDM_DATA_RESOURCE_ID_LEN_BYTES  64
+#define IDM_DATA_METADATA_LEN_BYTES     64
+#define IDM_DATA_HOST_ID_LEN_BYTES      32
+#define IDM_DATA_RESERVED_1_LEN_BYTES   32
+
 typedef struct _idmData {
     union {
         uint64_t    state;           // For idm_read
@@ -73,12 +81,12 @@ typedef struct _idmData {
     };
     uint64_t    countdown;
     uint64_t    class_idm;
-    char        resource_ver[8];
-    char        rsvd0[24];
-    char        resource_id[64];
-    char        metadata[64];
-    char        host_id[32];
-    char        rsvd1[32];
+    char        resource_ver[IDM_DATA_RESOURCE_VER_LEN_BYTES];
+    char        rsvd0[IDM_DATA_RESERVED_0_LEN_BYTES];
+    char        resource_id[IDM_DATA_RESOURCE_ID_LEN_BYTES];
+    char        metadata[IDM_DATA_METADATA_LEN_BYTES];
+    char        host_id[IDM_DATA_HOST_ID_LEN_BYTES];
+    char        rsvd1[IDM_DATA_RESERVED_1_LEN_BYTES];
     union {
         uint64_t    rsvd2[256];      // For idm_read
         uint64_t    ignored1[256];   // For idm_write

--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_cmd_common.h - In-drive Mutex (IDM) related structs, enums, etc. that are common to SCSI and NVMe.
+ */
+
+
+//TODO: Double-check SCSI code to see if some\all of these exist already
+//      Replace as necessary
+
+#include <stdint.h>
+
+
+#define IDM_VENDOR_CMD_DATA_LEN_BYTES   512            //TODO: Find where this is implemented on SCSI
+#define IDM_VENDOR_CMD_DATA_LEN_DWORDS  512 / 4
+
+typedef enum _eIdmOpcodes {
+    IDM_OPCODE_NORMAL   = 0x0,
+    IDM_OPCODE_INIT     = 0x1,
+    IDM_OPCODE_TRYLOCK  = 0x2,
+    IDM_OPCODE_LOCK     = 0x3,
+    IDM_OPCODE_UNLOCK   = 0x4,
+    IDM_OPCODE_REFRESH  = 0x5,
+    IDM_OPCODE_BREAK    = 0x6,
+    IDM_OPCODE_DESTROY  = 0x7,
+}eIdmOpcodes;  //NVMe CDW12 mutex opcode
+
+typedef enum _eIdmStates {
+    IDM_STATE_UNINIT            = 0,
+    IDM_STATE_LOCKED            = 0x101,
+    IDM_STATE_UNLOCKED          = 0x102,
+    IDM_STATE_MULTIPLE_LOCKED   = 0x103,
+    IDM_STATE_TIMEOUT           = 0x104,
+    IDM_STATE_DEAD              = 0xdead,
+}eIdmStates;
+
+typedef enum _eIdmClasses {
+    IDM_CLASS_EXCLUSIVE             = 0,
+    IDM_CLASS_PROTECTED_WRITE       = 0x1,
+    IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
+}eIdmClasses;
+
+typedef struct _idmData {
+    union {
+        uint64_t    state;           // For idm_read
+        uint64_t    ignored0;        // For idm_write
+    };
+    union {
+        uint64_t    modified;        // For idm_read
+        uint64_t    time_now;        // For idm_write
+    };
+    uint64_t    countdown;
+    uint64_t    class_;
+    char        resource_ver[8];
+    char        rsvd0[24];
+    char        resource_id[64];
+    char        metadata[64];
+    char        host_id[32];
+    char        rsvd1[32];
+    union {
+        uint64_t    rsvd2[256];      // For idm_read
+        uint64_t    ignored1[256];   // For idm_write
+    };
+}idmData;
+

--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -13,6 +13,13 @@
 #include <stdint.h>
 
 
+// #define C_CAST(type, val) (type)(val)
+
+#define SUCCESS 0;
+#define FAILURE -1;
+
+
+
 #define IDM_VENDOR_CMD_DATA_LEN_BYTES   512            //TODO: Find where this is implemented on SCSI
 #define IDM_VENDOR_CMD_DATA_LEN_DWORDS  512 / 4
 
@@ -36,11 +43,24 @@ typedef enum _eIdmStates {
     IDM_STATE_DEAD              = 0xdead,
 }eIdmStates;
 
-typedef enum _eIdmClasses {
+typedef enum _eIdmModes {
     IDM_CLASS_EXCLUSIVE             = 0,
     IDM_CLASS_PROTECTED_WRITE       = 0x1,
     IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
+}eIdmModes;
+
+typedef enum _eIdmClasses {
+    IDM_MODE_UNLOCK    = 0,
+    IDM_MODE_EXCLUSIVE = 0x1,
+    IDM_MODE_SHAREABLE = 0x2,
 }eIdmClasses;
+
+typedef enum _eIdmResVer {
+    IDM_RES_VER_NO_UPDATE_NO_VALID = 0,
+    IDM_RES_VER_UPDATE_NO_VALID    = 0x1,
+    IDM_RES_VER_UPDATE_VALID       = 0x2,
+    IDM_RES_VER_INVALID            = 0x3,
+}eIdmResVer;
 
 typedef struct _idmData {
     union {
@@ -52,7 +72,7 @@ typedef struct _idmData {
         uint64_t    time_now;        // For idm_write
     };
     uint64_t    countdown;
-    uint64_t    class_;
+    uint64_t    class_idm;
     char        resource_ver[8];
     char        rsvd0[24];
     char        resource_id[64];
@@ -64,4 +84,3 @@ typedef struct _idmData {
         uint64_t    ignored1[256];   // For idm_write
     };
 }idmData;
-

--- a/src/idm_nvme.c
+++ b/src/idm_nvme.c
@@ -51,12 +51,12 @@ void gen_nvme_cmd_identify(struct nvme_admin_cmd *cmd_admin, nvmeIDCtrl *data_id
  *
  */
 void gen_nvme_cmd_idm_read(nvmeIdmVendorCmd *cmd_idm_read,
-                           idmReadData *data_idm_read,
+                           idmData *data_idm_read,
                            uint8_t idm_opcode,
                            uint8_t idm_group) {
 
     memset(cmd_idm_read,  0, sizeof(nvmeIdmVendorCmd));
-    memset(data_idm_read, 0, sizeof(idmReadData));
+    memset(data_idm_read, 0, sizeof(idmData));
 
     cmd_idm_read->opcode             = NVME_IDM_VENDOR_CMD_OP_READ;
     cmd_idm_read->addr               = C_CAST(uint64_t, C_CAST(uintptr_t, data_idm_read));
@@ -78,12 +78,12 @@ void gen_nvme_cmd_idm_read(nvmeIdmVendorCmd *cmd_idm_read,
  *
  */
 void gen_nvme_cmd_idm_write(nvmeIdmVendorCmd *cmd_idm_write,
-                            idmWriteData *data_idm_write,
+                            idmData *data_idm_write,
                             uint8_t idm_opcode,
                             uint8_t idm_group) {
 
     memset(cmd_idm_write,  0, sizeof(nvmeIdmVendorCmd));
-    memset(data_idm_write, 0, sizeof(idmWriteData));
+    memset(data_idm_write, 0, sizeof(idmData));
 
     cmd_idm_write->opcode             = NVME_IDM_VENDOR_CMD_OP_WRITE;
     cmd_idm_write->addr               = C_CAST(uint64_t, C_CAST(uintptr_t, data_idm_write));
@@ -142,7 +142,7 @@ int nvme_idm_read(char *drive, uint8_t idm_opcode, uint8_t idm_group) {
 //          Likely need to move these up a "layer"
 //          Likely need to start combining passed in params into a single common struct
     nvmeIdmVendorCmd cmd_idm_read;
-    idmReadData data_idm_read;
+    idmData data_idm_read;
     int ret = SUCCESS;
 
     gen_nvme_cmd_idm_read(&cmd_idm_read, &data_idm_read, idm_opcode, idm_group);
@@ -175,7 +175,7 @@ int nvme_idm_write(char *drive, uint8_t idm_opcode, uint8_t idm_group) {
 //          Likely need to move these up a "layer"
 //          Likely need to start combining passed in params into a single common struct
     nvmeIdmVendorCmd cmd_idm_write;
-    idmWriteData data_idm_write;
+    idmData data_idm_write;
     int ret = SUCCESS;
 
     gen_nvme_cmd_idm_write(&cmd_idm_write, &data_idm_write, idm_opcode, idm_group);

--- a/src/idm_nvme.h
+++ b/src/idm_nvme.h
@@ -8,12 +8,17 @@
 
 #include <stdint.h>
 
+#include "idm_cmd_common.h"
+
 
 #define ADMIN_CMD_TIMEOUT_DEFAULT 15
 #define NVME_IDENTIFY_DATA_LEN    4096
 
 #define C_CAST(type, val) (type)(val)
 
+//////////////////////////////////////////
+// Admin Command Enums
+//////////////////////////////////////////
 // From Seagate/opensea-transport/include/nvme_helper.h
 typedef enum _eNVMeAdminOpCodes {
     // NVME_ADMIN_CMD_DELETE_SQ                    = 0x00,
@@ -182,7 +187,7 @@ typedef enum _eNvmeVendorCmdOpcodes {
 typedef struct _nvmeIdmVendorCmd {
     uint8_t             opcode;       //CDW0
     uint8_t             flags;        //CDW0
-    uint16_t            commandId;    //CDW0
+    uint16_t            command_id;    //CDW0
     uint32_t            nsid;         //CDW1
     uint32_t            cdw2;         //CDW2
     uint32_t            cdw3;         //CDW3
@@ -230,77 +235,11 @@ typedef struct _nvmeIdmVendorCmd {
 
 
 
-////////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////// COMMON ///////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////
-
-//TODO: Move EVERYTHING in this section to a idm_common.h file
-//  Use for all new NVMe code
-//  Double-check SCSI code to see if some\all of these exist already
-//      Replace as necessary
-
-
-#define IDM_VENDOR_CMD_DATA_LEN_BYTES   512            //TODO: Find where this is implemented on SCSI
-#define IDM_VENDOR_CMD_DATA_LEN_DWORDS  512 / 4
-
-typedef enum _eIdmOpcodes {
-    IDM_OPCODE_NORMAL   = 0x0,
-    IDM_OPCODE_INIT     = 0x1,
-    IDM_OPCODE_TRYLOCK  = 0x2,
-    IDM_OPCODE_LOCK     = 0x3,
-    IDM_OPCODE_UNLOCK   = 0x4,
-    IDM_OPCODE_REFRESH  = 0x5,
-    IDM_OPCODE_BREAK    = 0x6,
-    IDM_OPCODE_DESTROY  = 0x7,
-}eIdmOpcodes;  //NVMe CDW12 mutex opcode
-
-typedef enum _eIdmStates {
-    IDM_STATE_UNINIT            = 0,
-    IDM_STATE_LOCKED            = 0x101,
-    IDM_STATE_UNLOCKED          = 0x102,
-    IDM_STATE_MULTIPLE_LOCKED   = 0x103,
-    IDM_STATE_TIMEOUT           = 0x104,
-    IDM_STATE_DEAD              = 0xdead,
-}eIdmStates;
-
-typedef enum _eIdmClasses {
-    IDM_CLASS_EXCLUSIVE             = 0,
-    IDM_CLASS_PROTECTED_WRITE       = 0x1,
-    IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
-}eIdmClasses;
-
-typedef struct _idmData {
-    union {
-        uint64_t    state;           // For idm_read
-        uint64_t    ignored0;        // For idm_write
-    };
-    union {
-        uint64_t    modified;        // For idm_read
-        uint64_t    time_now;        // For idm_write
-    };
-    uint64_t    countdown;
-    uint64_t    class;
-    char        resource_ver[8];
-    char        rsvd0[24];
-    char        resource_id[64];
-    char        metadata[64];
-    char        host_id[32];
-    char        rsvd1[32];
-    union {
-        uint64_t    rsvd2[256];      // For idm_read
-        uint64_t    ignored1[256];   // For idm_write
-    };
-}idmData;
 
 
 
-////////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////// COMMON - END ///////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////
+
+
 
 
 

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -43,6 +43,7 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
 
     printf("%s: START\n", __func__);
 
+//TODO: Should I be using malloc() instead?
     nvmeIdmRequest   request_idm;
     nvmeIdmVendorCmd cmd_idm;
     idmData          data_idm;
@@ -52,7 +53,7 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
     #ifndef COMPILE_STANDALONE
     if (ilm_inject_fault_is_hit())
         return -EIO;
-    #endif
+    #endif //COMPILE_STANDALONE
 
     if (!lock_id || !host_id || !drive)
         return -EINVAL;
@@ -87,6 +88,12 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
     request_idm.data_len     = sizeof(idmData);         //TODO: review this.  This can happen later
 
     ret = nvme_idm_write(&request_idm);
+    if (ret < 0)
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: command fail %d", __func__, ret);
+        #else
+        printf("%s: command fail %d\n", __func__, ret);
+        #endif //COMPILE_STANDALONE
 
     return ret;
 }

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme_api.c - Primary NVMe interface for In-drive Mutex (IDM)
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/nvme_ioctl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>       //TODO: Do I need BOTH ioctl includes?
+#include <unistd.h>
+
+#include "idm_nvme_api.h"
+#include "idm_nvme_io.h"
+
+
+//////////////////////////////////////////
+// COMPILE FLAGS
+//////////////////////////////////////////
+//TODO: Keep this (and the corresponding #ifdef's)???
+#define COMPILE_STANDALONE
+#define MAIN_ACTIVATE
+
+
+//////////////////////////////////////////
+// FUNCTIONS
+//////////////////////////////////////////
+/**
+ * idm_nvme_drive_lock - acquire an IDM on a specified NVMe drive
+ * @lock_id:     Lock ID (64 bytes).
+ * @mode:        Lock mode (unlock, shareable, exclusive).
+ * @host_id:     Host ID (32 bytes).
+ * @drive:       Drive path name.
+ * @timeout:     Timeout for membership (unit: millisecond).
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout) {
+
+    printf("%s: START\n", __func__);
+
+    nvmeIdmRequest   request_idm;
+    nvmeIdmVendorCmd cmd_idm;
+    idmData          data_idm;
+    int              ret = SUCCESS;
+
+//TODO: Common function for init error checking???
+    #ifndef COMPILE_STANDALONE
+    if (ilm_inject_fault_is_hit())
+        return -EIO;
+    #endif
+
+    if (!lock_id || !host_id || !drive)
+        return -EINVAL;
+
+    if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
+        return -EINVAL;
+
+    nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
+                        lock_id, mode, host_id,drive, timeout, 0, 0);
+
+//TODO: Remove this comment
+	// if (mode == IDM_MODE_EXCLUSIVE)
+	// 	mode = IDM_CLASS_EXCLUSIVE;
+	// else if (mode == IDM_MODE_SHAREABLE)
+	// 	mode = IDM_CLASS_SHARED_PROTECTED_READ;
+
+//Start API-specific settings
+    switch(mode) {
+        case IDM_MODE_EXCLUSIVE:
+            request_idm.class_idm = IDM_CLASS_EXCLUSIVE;
+        case IDM_MODE_SHAREABLE:
+            request_idm.class_idm = IDM_CLASS_SHARED_PROTECTED_READ;
+        default:
+//TODO: This case is the resultant default behavior of the equivalent scsi code.  Does this make sense???
+//          Talk to Tom about this.
+//          Feels like this should be an error
+            request_idm.class_idm = mode;
+    }
+
+    request_idm.opcode_idm   = IDM_OPCODE_TRYLOCK;
+    request_idm.res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
+    request_idm.data_len     = sizeof(idmData);         //TODO: review this.  This can happen later
+
+    ret = nvme_idm_write(&request_idm);
+
+    return ret;
+}
+
+
+
+
+#ifdef MAIN_ACTIVATE
+/*#########################################################################################
+########################### STAND-ALONE MAIN ##############################################
+#########################################################################################*/
+#define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1";
+
+//To compile:
+//gcc idm_nvme_api.c -o idm_nvme_api
+int main(int argc, char *argv[])
+{
+    char *drive;
+    int  ret = 0;
+
+    if(argc >= 3){
+        drive = argv[2];
+    }
+    else {
+        drive = DRIVE_DEFAULT_DEVICE;
+    }
+
+    //cli usage: idm_nvme_api lock
+    if(argc >= 2){
+        if(strcmp(argv[1], "lock") == 0){
+            char        lock_id[64] = "lock_id";
+            int         mode        = IDM_MODE_EXCLUSIVE;
+            char        host_id[32] = "host_id";
+            uint64_t    timeout     = 10;
+            ret = idm_nvme_drive_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+            printf("%s exiting with %d\n", argv[1], ret);
+        }
+
+    }
+
+    return 0;
+}
+#endif//MAIN_ACTIVATE

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme_api.h - Primary NVMe interface for the In-drive Mutex (IDM)
+  */
+
+#include <stdint.h>
+
+
+int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -1,0 +1,247 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme_io.c - Contains the lowest-level function that allow the IDM In-drive Mutex (IDM)
+ *                  to talk to the Linux kernel (via ioctl(), read() or write())
+ */
+
+#include <fcntl.h>
+#include <linux/nvme_ioctl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>       //TODO: Do I need BOTH ioctl includes?
+#include <unistd.h>
+
+#include "idm_nvme_io.h"
+
+
+//////////////////////////////////////////
+// COMPILE FLAGS
+//////////////////////////////////////////
+//TODO: Keep this (and the corresponding #ifdef's)???
+#define COMPILE_STANDALONE
+// #define MAIN_ACTIVATE
+
+
+//////////////////////////////////////////
+// FUNCTIONS
+//////////////////////////////////////////
+int nvme_idm_write(nvmeIdmRequest *request_idm) {
+
+    printf("%s: START\n", __func__);
+
+    nvmeIdmVendorCmd *cmd_idm  = request_idm->cmd_idm;
+    idmData *data_idm          = request_idm->data_idm;
+    int ret                    = SUCCESS;
+
+    ret = _nvme_idm_cmd_init_wrt(request_idm);
+    //TODO: Error handling (HERE -OR- push DOWN 1 level??)
+
+    ret = _nvme_idm_data_init_wrt(request_idm);
+    //TODO: Error handling (HERE -OR- push DOWN 1 level??)
+
+    ret = _nvme_send_cmd_idm(request_idm);
+    //TODO: Error handling (HERE -OR- push DOWN 1 level??)
+
+//TODO: what do with this debug code?
+    printf("%s: data_idm_write.resource_id = %s\n", __func__, data_idm->resource_id);
+    printf("%s: data_idm_write.time_now = %s\n"   , __func__, data_idm->time_now);
+
+    return ret;
+}
+
+//TODO: Attempt at a "common" write initialization, with some caveats (of course).
+//TODO: KEEP THIS?????
+int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_idm,
+                         idmData *data_idm, char *lock_id, int mode, char *host_id,
+                         char *drive, uint64_t timeout, char *lvb, int lvb_size) {
+
+//TODO: Leave these in under DEBUG flag??
+    printf("%s: START\n", __func__);
+
+    int ret = SUCCESS;
+
+    memset(request_idm, 0, sizeof(nvmeIdmRequest));
+    memset(cmd_idm,     0, sizeof(nvmeIdmVendorCmd));
+    memset(data_idm,    0, sizeof(idmData));
+
+    request_idm->lock_id  = lock_id;
+    request_idm->mode_idm = mode;
+    request_idm->host_id  = host_id;
+    request_idm->drive    = drive;
+
+    request_idm->cmd_idm  = cmd_idm;
+    request_idm->data_idm = data_idm;
+
+//TODO: Command dependent variables: Leave here -OR- move up 1 level?
+    //kludge for inconsistent input params
+    if(timeout)
+        request_idm->timeout  = timeout;
+    if(lvb)
+        request_idm->lvb = lvb;
+    if(lvb_size)
+        request_idm->lvb_size  = lvb_size;
+
+    return ret;
+}
+
+int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme) {
+
+    printf("%s: START\n", __func__);
+
+    nvmeIdmVendorCmd *cmd_idm  = request_idm->cmd_idm;
+    idmData *data_idm          = request_idm->data_idm;
+    int ret                    = SUCCESS;
+
+    cmd_idm->opcode_nvme        = opcode_nvme;
+    cmd_idm->addr               = (uint64_t)(uintptr_t)data_idm;
+    cmd_idm->data_len           = IDM_VENDOR_CMD_DATA_LEN_BYTES;  //Should be: sizeof(idmData) which should always be 512
+    cmd_idm->ndt                = IDM_VENDOR_CMD_DATA_LEN_DWORDS;
+//TODO: Change spec so don't have to do this 4-bit shift
+    cmd_idm->opcode_idm_bits7_4 = request_idm->opcode_idm << 4;
+    cmd_idm->group_idm          = request_idm->group_idm;       //TODO: This isn't yet getting set anywhere for lock
+    cmd_idm->timeout_ms         = VENDOR_CMD_TIMEOUT_DEFAULT;  //TODO: ??  THis vs the timout param passed in??
+
+    return ret;
+}
+
+//TODO: Bring this back in when doing "read" side.
+// int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm) {
+//     return _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
+// }
+
+int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm) {
+    printf("%s: START\n", __func__);
+
+    return _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
+}
+
+int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm) {
+
+    printf("%s: START\n", __func__);
+
+    nvmeIdmVendorCmd *cmd_idm = request_idm->cmd_idm;
+    idmData *data_idm         = request_idm->data_idm;
+    int ret                   = SUCCESS;
+
+//TODO: ?? __bswap_64() the next 3 rhs values??
+    #ifndef COMPILE_STANDALONE
+  	data_idm->time_now  = ilm_read_utc_time();
+    #else
+  	data_idm->time_now  = 0;
+    #endif//COMPILE_STANDALONE
+	data_idm->countdown = request_idm->timeout;
+	data_idm->class_idm = request_idm->class_idm;
+
+//TODO: ?? reverse order of next 3 rhs arrays ??  (on scsi-side, using _scsi_data_swap())
+    memcpy(data_idm->resource_id,  request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
+    memcpy(data_idm->host_id,      request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
+    memcpy(data_idm->resource_ver, request_idm->lvb,     request_idm->lvb_size);  //TOO: Not always needed.  Copy anyway?  Conditional IF?
+
+	data_idm->resource_ver[0] = request_idm->res_ver_type;                     //TODO: What the heck is going on HERE?!?
+
+    return ret;
+}
+
+int _nvme_send_cmd_idm(nvmeIdmRequest *request_idm) {
+
+    printf("%s: START\n", __func__);
+
+    int nvme_fd;
+    int ret = SUCCESS;
+
+    if ((nvme_fd = open(request_idm->drive, O_RDWR | O_NONBLOCK)) < 0) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: error opening drive %s fd %d",
+                __func__, request_idm->drive, nvme_fd);
+        #else
+        printf("%s: error opening drive %s fd %d\n",
+                __func__, request_idm->drive, nvme_fd);
+        #endif//COMPILE_STANDALONE
+        return nvme_fd;
+    }
+
+    ret = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, request_idm->cmd_idm);
+    if(ret) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: ioctl failed: %d", __func__, ret);
+        #else
+        printf("%s: ioctl failed: %d\n", __func__, ret);
+        #endif//COMPILE_STANDALONE
+        goto out;
+    }
+
+//TODO: Keep this debug??
+    printf("%s: ioctl ret=%d\n", __func__, ret);
+    printf("%s: ioctl cmd_idm->result=%d\n", __func__, request_idm->cmd_idm->result);
+
+//Completion Queue Entry (CQE) SIDE-NOTE:
+// CQE DW0[31:0]  == cmd_admin->result
+// CQE DW3[31:17] == ret                //?? is "ret" just [24:17]??
+
+out:
+//TODO: Possible ASYNC flag HERE??  -OR-  do I need to use write() and read() for async?? (like scsi)
+    // if(async) {
+    //     request_idm->fd = nvme_fd;  //async, so save nvme_fd for later
+    // }
+    // else {
+    //     close(nvme_fd);              //sunc, so done with nvme_fd.
+    // }
+    close(nvme_fd);
+    return ret;
+}
+
+
+
+#ifdef MAIN_ACTIVATE
+/*#########################################################################################
+########################### STAND-ALONE MAIN ##############################################
+#########################################################################################*/
+#define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1";
+
+//To compile:
+//gcc idm_nvme_io.c -o idm_nvme_io
+int main(int argc, char *argv[])
+{
+    char *drive;
+
+    if(argc >= 3){
+        drive = argv[2];
+    }
+    else {
+        drive = DRIVE_DEFAULT_DEVICE;
+    }
+
+    //cli usage: idm_nvme_io write
+    if(argc >= 2){
+        if(strcmp(argv[1], "write") == 0){
+
+            //Simulated ILM input
+            char        lock_id[64] = "lock_id";
+            int         mode        = IDM_MODE_EXCLUSIVE;
+            char        host_id[32] = "host_id";
+            char        drive[256]  = "/dev/nvme0n1";
+            uint64_t    timeout     = 10;
+
+            //Create required input structs the IDM API would normally create
+            nvmeIdmRequest   request_idm;
+            nvmeIdmVendorCmd cmd_idm;
+            idmData          data_idm;
+            int              ret = SUCCESS;
+
+            ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
+                                      lock_id, mode, host_id,drive, timeout, 0, 0);
+            printf("%s exiting with %d\n", argv[1], ret);
+
+            ret = nvme_idm_write(&request_idm);
+            printf("%s exiting with %d\n", argv[1], ret);
+        }
+
+    }
+
+
+    return 0;
+}
+#endif//MAIN_ACTIVATE

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -38,18 +38,29 @@ int nvme_idm_write(nvmeIdmRequest *request_idm) {
     int ret                    = SUCCESS;
 
     ret = _nvme_idm_cmd_init_wrt(request_idm);
-    //TODO: Error handling (HERE -OR- push DOWN 1 level??)
+    if(ret < 0) {
+        goto EXIT_NVME_IDM_WRITE;
+    }
 
     ret = _nvme_idm_data_init_wrt(request_idm);
-    //TODO: Error handling (HERE -OR- push DOWN 1 level??)
+    if(ret < 0) {
+        goto EXIT_NVME_IDM_WRITE;
+    }
+
+    #ifndef COMPILE_STANDALONE
+	ilm_log_array_dbg("resource_ver", data_idm->resource_ver, IDM_DATA_RESOURCE_VER_LEN_BYTES);
+    #endif
 
     ret = _nvme_send_cmd_idm(request_idm);
-    //TODO: Error handling (HERE -OR- push DOWN 1 level??)
+    if(ret < 0) {
+        goto EXIT_NVME_IDM_WRITE;
+    }
 
 //TODO: what do with this debug code?
     printf("%s: data_idm_write.resource_id = %s\n", __func__, data_idm->resource_id);
     printf("%s: data_idm_write.time_now = %s\n"   , __func__, data_idm->time_now);
 
+EXIT_NVME_IDM_WRITE:
     return ret;
 }
 
@@ -211,19 +222,23 @@ int _nvme_status_check(int status, int opcode_idm) {
 
     int ret;
 
-//TODO: These do NOT match 1-to-1 with SCSI side.
 //TODO: can NOT decipher hardcoded SCSI "Sense" data in Propeller NVMe spec
     switch(status) {
-        // case NVME_IDM_ERR_MUTEX_OP_FAILURE:
-        //     break;
-        // case NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE:
-        //     break;
-        // case NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE:
-        //     break;
-        // case NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS:
-        //     break;
-        // case NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER:
-        //     break;
+        case NVME_IDM_ERR_MUTEX_OP_FAILURE:
+            ret = -EINVAL;
+            break;
+        case NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE:
+            ret = -EINVAL;
+            break;
+        case NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE:
+            ret = -EINVAL;
+            break;
+        case NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS:
+            ret = -EINVAL;
+            break;
+        case NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER:
+            ret = -EINVAL;
+            break;
         case NVME_IDM_ERR_MUTEX_OPCODE_INVALID:
             ret = -EINVAL;
             break;

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -29,6 +29,15 @@
 //////////////////////////////////////////
 // FUNCTIONS
 //////////////////////////////////////////
+
+/**
+ * nvme_idm_write - Issues a custom (vendor-specific) NVMe write command to the IDM.
+ *                  Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 int nvme_idm_write(nvmeIdmRequest *request_idm) {
 
     printf("%s: START\n", __func__);
@@ -64,6 +73,25 @@ EXIT_NVME_IDM_WRITE:
     return ret;
 }
 
+/**
+ * nvme_idm_write_init - Collects all the parameters passed to the IDM API and stores them in
+ *                       the "request_idm" data struct for use later (but before the NVMe write
+ *                       command is sent to the OS kernel).
+ *                       Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @cmd_idm:        NVMe Vendor Specific Command command word data structure
+ * @data_idm:       IDM-specific data structure
+ * @lock_id:        Lock ID (64 bytes).
+ * @mode:           Lock mode (unlock, shareable, exclusive).
+ * @host_id:        Host ID (32 bytes).
+ * @drive:          Drive path name.
+ * @timeout:        Timeout for membership (unit: millisecond).
+ * @lvb:            Lock value block pointer.
+ * @lvb_size:       Lock value block size.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 //TODO: Attempt at a "common" write initialization, with some caveats (of course).
 //TODO: KEEP THIS?????
 int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_idm,
@@ -99,6 +127,14 @@ int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_idm,
     return ret;
 }
 
+/**
+ * _nvme_idm_cmd_init -  Initializes the NVMe Vendor Specific Command command struct.
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @opcode_nvme:    NVMe-specific opcode specifying the desired NVMe action to perform on the IDM.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme) {
 
     printf("%s: START\n", __func__);
@@ -119,17 +155,40 @@ int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme) {
     return ret;
 }
 
+/**
+ * _nvme_idm_cmd_init_rd - Convenience function (during an NVMe read of the IDM) for initializing
+ *                         the NVMe Vendor Specific Command command struct.
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 //TODO: Bring this back in when doing "read" side.
 // int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm) {
 //     return _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
 // }
 
+/**
+ * _nvme_idm_cmd_init_wrt - Convenience function (during an NVMe write of the IDM) for initializing
+ *                          the NVMe Vendor Specific Command command struct.
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm) {
     printf("%s: START\n", __func__);
 
     return _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
 }
 
+/**
+ * _nvme_idm_data_init_wrt -  Initializes the IDM's data struct prior to an IDM write.
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm) {
 
     printf("%s: START\n", __func__);
@@ -157,6 +216,13 @@ int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm) {
     return ret;
 }
 
+/**
+ * _nvme_send_cmd_idm -  Sends the completed NVMe command data structure to the OS kernel.
+ *
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 int _nvme_send_cmd_idm(nvmeIdmRequest *request_idm) {
 
     printf("%s: START\n", __func__);
@@ -218,6 +284,14 @@ out:
     return ret;
 }
 
+/**
+ * _nvme_status_check -  Checks the NVMe command status code returned from the OS kernel.
+ *
+ * @status:     The status code returned by the OS kernel after the completed NVMe command request.
+ * @opcode_idm: IDM-specific opcode specifying the desired IDM action performed.
+*
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
 int _nvme_status_check(int status, int opcode_idm) {
 
     int ret;

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -22,10 +22,26 @@
 // Enums
 //////////////////////////////////////////
 //Custom (vendor-specific) NVMe opcodes sent via CDW0[7:0] of nvmeIdmVendorCmd
-typedef enum _eNvmeVendorCmdOpcodes {
+typedef enum _eNvmeIdmVendorCmdOpcodes {
     NVME_IDM_VENDOR_CMD_OP_WRITE = 0xC1,
     NVME_IDM_VENDOR_CMD_OP_READ  = 0xC2,
-} eNvmeVendorCmdOpcodes;
+} eNvmeIdmVendorCmdOpcodes;
+
+typedef enum _eNvmeIdmErrorCodes {
+    NVME_IDM_ERR_MUTEX_OP_FAILURE                  = 0xC0,    //SCSI Equivalent: 0x04042200
+    NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE = 0xC1,    //SCSI Equivalent: 0x04042201
+    NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE            = 0xC2,    //SCSI Equivalent: 0x04042202
+    NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS            = 0xC3,    //SCSI Equivalent: 0x04042203
+    NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER            = 0xC4,    //SCSI Equivalent: 0x04042204
+    NVME_IDM_ERR_MUTEX_OPCODE_INVALID              = 0xC5,    //SCSI Equivalent: 0x0520000A
+    NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED              = 0xC6,    //SCSI Equivalent: 0x0B550300
+    NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST         = 0xC7,    //SCSI Equivalent: 0x0B550301
+    NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST  = 0xC8,    //SCSI Equivalent: 0x0B550302
+    NVME_IDM_ERR_MUTEX_CONFLICT                    = 0xC9,    //SCSI Equivalent: Res Conf
+    NVME_IDM_ERR_MUTEX_HELD_ALREADY                = 0xCA,    //SCSI Equivalent: Terminated
+    NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER             = 0xCB,    //SCSI Equivalent: Busy
+}eNvmeIdmErrorCodes;
+
 
 //////////////////////////////////////////
 // Structs

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -137,5 +137,4 @@ int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme);
 int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm);
 int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm);
 int _nvme_send_cmd_idm(nvmeIdmRequest *request_idm);
-
-
+int _nvme_status_check(int status, int opcode_idm);

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme_io.h - Contains the lowest-level function that allow the IDM In-drive Mutex (IDM)
+ *                  to talk to the Linux kernel (via ioctl(), read() or write())
+*/
+
+#include <stdint.h>
+
+#include "idm_cmd_common.h"
+
+
+#define VENDOR_CMD_TIMEOUT_DEFAULT 15000     //TODO: Duplicated from SCSI. Uncertain behavior
+                                            //TODO: Separate timeout default for NVMe Vendor Cmds??
+#define IDM_LOCK_ID_LEN_BYTES   64
+#define IDM_HOST_ID_LEN_BYTES   32
+
+
+//////////////////////////////////////////
+// Enums
+//////////////////////////////////////////
+//Custom (vendor-specific) NVMe opcodes sent via CDW0[7:0] of nvmeIdmVendorCmd
+typedef enum _eNvmeVendorCmdOpcodes {
+    NVME_IDM_VENDOR_CMD_OP_WRITE = 0xC1,
+    NVME_IDM_VENDOR_CMD_OP_READ  = 0xC2,
+} eNvmeVendorCmdOpcodes;
+
+//////////////////////////////////////////
+// Structs
+//////////////////////////////////////////
+//TODO: Add struct description HERE
+typedef struct _nvmeIdmVendorCmd {
+//TODO: change to "opcode_nvme" (to clarify against "opcode_idm" (change below))
+    uint8_t             opcode_nvme;  //CDW0
+    uint8_t             flags;        //CDW0
+    uint16_t            command_id;   //CDW0
+    uint32_t            nsid;         //CDW1
+    uint32_t            cdw2;         //CDW2
+    uint32_t            cdw3;         //CDW3
+    uint64_t            metadata;     //CDW4 & 5
+//CDW 6 - 9: Used when talking to the kernel layer (via ioctl()).
+    uint64_t            addr;         //CDW6 & 7
+    uint32_t            metadata_len; //CDW8
+    uint32_t            data_len;     //CDW9
+//CDW 6 - 9: Used when talking directly to the drive firmware layer, I think.
+    // uint64_t            prp1;        //CDW6 & 7
+    // uint64_t            prp2;        //CDW8 & 9
+    uint32_t            ndt;          //CDW10
+    uint32_t            ndm;          //CDW11
+//TODO: Move bit fields in CDW12. (saves a bit shift, at least for me)
+//  idm_group[7:0]
+//  idm_opcode_bits11_8[11:8]
+    uint8_t             opcode_idm_bits7_4;   //CDW12   // bits[7:4].  Lower nibble reserved.
+    uint8_t             group_idm;    //CDW12
+    uint16_t            rsvd2;        //CDW12
+    uint32_t            cdw13;        //CDW13
+    uint32_t            cdw14;        //CDW14
+    uint32_t            cdw15;        //CDW15
+    uint32_t            timeout_ms;   //Same as nvme_admin_cmd when using ioctl()??
+    uint32_t            result;       //Same as nvme_admin_cmd when using ioctl()??
+}nvmeIdmVendorCmd;
+
+
+
+// //This struct represents the pieces of the status word that is returned from ioctl()
+// // This bit field definitions of the status are defined in DWord3[31:17] of the NVMe spec's Common
+// // Completion Queue Entry (CQE).
+// //TODO: What does ioctl() return?  Just status code OR the entire DW3 status field.
+
+// //Note that bits [14:0] of ioctl()'s return status word contain bits[31/24:17] above.
+// typedef struct _eCqeStatusFields {
+//     uint8_t     dnr;        //Do Not Retry          (CQE DWord3[31])
+//     uint8_t     more;       //More                  (CQE DWord3[30])
+//     uint8_t     crd;        //Command Retry Delay   (CQE DWord3[29:28])
+//     uint8_t     sct;        //Status Code Type      (CQE DWord3[27:25])
+//     uint8_t     sc;         //Status Code           (CQE DWord3[24:17])
+// }eCqeStatusFields;
+
+
+//TODO: Using a bunch of pointer here.  SCSI was using COPIES of everything.  Any issues with this?? (string lengths??, kernel vs user space memory??)
+//TODO: Add struct description HERE
+typedef struct _nvmeIdmRequest {
+    //"IDM API" input params
+    char                *drive;
+	char                *lock_id;
+	char                *host_id;
+    int                 mode_idm;
+	//uint64_t            fd_async;
+	uint64_t            timeout;
+	char                *lvb;
+    int                 lvb_size;
+
+    //IDM core structs
+    nvmeIdmVendorCmd    *cmd_idm;
+    idmData             *data_idm;
+
+    // Misc collection area for kludgy smuggling of parameters
+    uint8_t             opcode_idm;
+    uint8_t             group_idm;
+    char                res_ver_type;  //TODO: How is this being used?  What does it represent in the NVMe CDW block?  What type should this be?
+    int                 data_len;       //TODO: Needed??  Seems like this can be determined in the lower-levels.
+    uint64_t            class_idm;
+
+}nvmeIdmRequest;
+
+
+
+//////////////////////////////////////////
+// Functions
+//////////////////////////////////////////
+
+int nvme_idm_write(nvmeIdmRequest *request_idm);
+int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_idm,
+                        idmData *data_idm, char *lock_id, int mode, char *host_id,
+                        char *drive, uint64_t timeout, char *lvb, int lvb_size);
+
+int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme);
+//int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm);
+int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm);
+int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm);
+int _nvme_send_cmd_idm(nvmeIdmRequest *request_idm);
+
+

--- a/src/idm_nvme_io_admin.c
+++ b/src/idm_nvme_io_admin.c
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme.c - NVMe interface for In-drive Mutex (IDM)
+ */
+
+#include <fcntl.h>
+#include <linux/nvme_ioctl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "idm_cmd_common.h"     //TODO: Only need this for #define's of SUCCESS\FAILURE.  Move them?
+#include "idm_nvme_io_admin.h"
+
+//////////////////////////////////////////
+// COMPILE FLAGS
+//////////////////////////////////////////
+//TODO: Keep this (and the corresponding #ifdef's)???
+#define COMPILE_STANDALONE
+#define MAIN_ACTIVATE
+
+
+//////////////////////////////////////////
+// FUNCTIONS
+//////////////////////////////////////////
+/**
+ * nvme_admin_identify - Send NVMe Identify Controller command to specified device.
+ * @drive:  Drive path name.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int nvme_admin_identify(char *drive) {
+
+    printf("%s: IN: drive=%s\n", __func__, drive);
+
+    struct nvme_admin_cmd cmd_admin;
+    nvmeIDCtrl data_identify_ctrl;
+    int ret = SUCCESS;
+//TODO: This should ALWAYS be 4096.  Make a compile check for this??
+    printf("sizeof(nvmeIDCtrl) = %d\n", sizeof(nvmeIDCtrl));
+
+    _gen_nvme_cmd_identify(&cmd_admin, &data_identify_ctrl);
+
+    ret = _send_nvme_cmd_admin(drive, &cmd_admin);
+
+//TODO: Keep this debug??
+    printf("%s: data_identify_ctrl.subnqn = %s\n", __func__, data_identify_ctrl.subnqn);
+
+    return ret;
+}
+
+/**
+ * gen_nvme_cmd_identify - Setup the NVMe ADmin command struct for Identify Controller (opcode=0x6)
+ * @cmd_admin:          NVMe Admin Command struct to fill
+ * @data_identify_ctrl: NVMe Admin Commmand data struct.  This is the cmd output destination.
+ *
+ */
+void _gen_nvme_cmd_identify(struct nvme_admin_cmd *cmd_admin, nvmeIDCtrl *data_identify_ctrl) {
+//TODO: Should this return "void"???
+    memset(cmd_admin,          0, sizeof(struct nvme_admin_cmd));
+    memset(data_identify_ctrl, 0, sizeof(nvmeIDCtrl));
+
+    cmd_admin->opcode     = NVME_ADMIN_CMD_IDENTIFY;
+    cmd_admin->addr       = (uint64_t)(uintptr_t)(data_identify_ctrl);
+    cmd_admin->data_len   = NVME_IDENTIFY_DATA_LEN_BYTES;
+    cmd_admin->cdw10      = NVME_IDENTIFY_CNS_CTRL;         // Set CNS
+    cmd_admin->timeout_ms = ADMIN_CMD_TIMEOUT_MS_DEFAULT;
+}
+
+/**
+ * send_nvme_cmd_admin - Send NVMe Admin command to specified device.
+ * @drive:      Drive path name.
+ * @cmd_admin:  NVMe Admin Command struct
+ *
+  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+*/
+int _send_nvme_cmd_admin(char *drive, struct nvme_admin_cmd *cmd_admin) {
+    int nvme_fd;
+    int ret = SUCCESS;
+
+    if ((nvme_fd = open(drive, O_RDWR | O_NONBLOCK)) < 0) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: error opening drive %s fd %d",
+                __func__, drive, nvme_fd);
+        #else
+        printf("%s: error opening drive %s fd %d\n",
+                __func__, drive, nvme_fd);
+        #endif
+        return nvme_fd;
+    }
+
+    ret = ioctl(nvme_fd, NVME_IOCTL_ADMIN_CMD, cmd_admin);
+    if(ret) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: ioctl failed: %d", __func__, ret);
+        #else
+        printf("%s: ioctl failed: %d\n", __func__, ret);
+        #endif
+        goto out;
+    }
+
+//TODO: Keep this debug??
+    printf("%s: ioctl ret=%d\n", __func__, ret);
+    printf("%s: ioctl cmd_admin->result=%d\n", __func__, cmd_admin->result);
+
+//Completion Queue Entry (CQE) SIDE-NOTE:
+// CQE DW0[31:0]  == cmd_admin->result
+// CQE DW3[31:17] == ret                //?? is "ret" just [24:17]??
+
+out:
+    close(nvme_fd);
+    return ret;
+}
+
+
+
+
+
+
+
+#ifdef MAIN_ACTIVATE
+/*#########################################################################################
+########################### STAND-ALONE MAIN ##############################################
+#########################################################################################*/
+#define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1";
+
+//To compile:
+//gcc idm_nvme_io_admin.c -o idm_nvme_io_admin
+int main(int argc, char *argv[])
+{
+    char *drive;
+    int  ret = 0;
+
+    if(argc >= 3){
+        drive = argv[2];
+    }
+    else {
+        drive = DRIVE_DEFAULT_DEVICE;
+    }
+
+    //cli usage: idm_nvme_io_admin identify
+    if(argc >= 2){
+        if(strcmp(argv[1], "identify") == 0){
+            ret = nvme_admin_identify(drive);
+            printf("%s exiting with %d\n", argv[1], ret);
+        }
+
+    }
+
+
+    return 0;
+}
+#endif//MAIN_ACTIVATE

--- a/src/idm_nvme_io_admin.h
+++ b/src/idm_nvme_io_admin.h
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme.h - NVMe interface for In-drive Mutex (IDM)
+ */
+
+#include <stdint.h>
+
+
+#define ADMIN_CMD_TIMEOUT_MS_DEFAULT 15000     //TODO: Duplicated from SCSI. Uncertain behavior
+                                            //TODO: Separate timeout default for NVMe Vendor Cmds??
+#define NVME_IDENTIFY_DATA_LEN_BYTES 4096
+
+//////////////////////////////////////////
+// Admin Command Enums
+//////////////////////////////////////////
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef enum _eNVMeAdminOpCodes {
+    // NVME_ADMIN_CMD_DELETE_SQ                    = 0x00,
+    // NVME_ADMIN_CMD_CREATE_SQ                    = 0x01,
+    // NVME_ADMIN_CMD_GET_LOG_PAGE                 = 0x02,
+    // NVME_ADMIN_CMD_DELETE_CQ                    = 0x04,
+    // NVME_ADMIN_CMD_CREATE_CQ                    = 0x05,
+    NVME_ADMIN_CMD_IDENTIFY                     = 0x06,
+    // NVME_ADMIN_CMD_ABORT_CMD                    = 0x08,
+    // NVME_ADMIN_CMD_SET_FEATURES                 = 0x09,
+    // NVME_ADMIN_CMD_GET_FEATURES                 = 0x0A,
+    // NVME_ADMIN_CMD_ASYNC_EVENT                  = 0x0C,
+    // NVME_ADMIN_CMD_NAMESPACE_MANAGEMENT         = 0x0D,
+    // NVME_ADMIN_CMD_ACTIVATE_FW                  = 0x10,
+    // NVME_ADMIN_CMD_DOWNLOAD_FW                  = 0x11,
+    // NVME_ADMIN_CMD_DEVICE_SELF_TEST             = 0x14,
+    // NVME_ADMIN_CMD_NAMESPACE_ATTACHMENT         = 0x15,
+    // NVME_ADMIN_CMD_KEEP_ALIVE                   = 0x18,
+    // NVME_ADMIN_CMD_DIRECTIVE_SEND               = 0x19,
+    // NVME_ADMIN_CMD_DIRECTIVE_RECEIVE            = 0x1A,
+    // NVME_ADMIN_CMD_VIRTUALIZATION_MANAGEMENT    = 0x1C,
+    // NVME_ADMIN_CMD_NVME_MI_SEND                 = 0x1D,
+    // NVME_ADMIN_CMD_NVME_MI_RECEIVE              = 0x1E,
+    // NVME_ADMIN_CMD_DOORBELL_BUFFER_CONFIG       = 0x7C,
+    // NVME_ADMIN_CMD_NVME_OVER_FABRICS            = 0x7F,
+    // NVME_ADMIN_CMD_FORMAT_NVM                   = 0x80,
+    // NVME_ADMIN_CMD_SECURITY_SEND                = 0x81,
+    // NVME_ADMIN_CMD_SECURITY_RECV                = 0x82,
+    // NVME_ADMIN_CMD_SANITIZE                     = 0x84,
+} eNVMeAdminOpCodes;
+
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef enum _eNvmeIdentifyCNS {
+    NVME_IDENTIFY_CNS_NS = 0,
+    NVME_IDENTIFY_CNS_CTRL = 1,
+    // NVME_IDENTIFY_CNS_ALL_ACTIVE_NS = 2,
+    // NVME_IDENTIFY_CNS_NS_ID_DESCRIPTOR_LIST = 3,
+} eNvmeIdentifyCNS;
+
+//////////////////////////////////////////
+// Structs for Admin Identify
+//////////////////////////////////////////
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef struct _nvmeIDPowerState {
+    uint16_t            maxPower;   /* centiwatts */
+    uint8_t             rsvd2;
+    uint8_t             flags;
+    uint32_t            entryLat;   /* microseconds */
+    uint32_t            exitLat;    /* microseconds */
+    uint8_t             readTPut;
+    uint8_t             readLat;
+    uint8_t             writeLput;
+    uint8_t             writeLat;
+    uint16_t            idlePower;
+    uint8_t             idleScale;
+    uint8_t             rsvd19;
+    uint16_t            activePower;
+    uint8_t             activeWorkScale;
+    uint8_t             rsvd23[9];
+}nvmeIDPowerState;
+
+// From Seagate/opensea-transport/include/nvme_helper.h
+typedef struct _nvmeIDCtrl {
+    //controller capabilities and features
+    uint16_t            vid;
+    uint16_t            ssvid;
+    char                sn[20];
+    char                mn[40];
+    char                fr[8];
+    uint8_t             rab;
+    uint8_t             ieee[3];
+    uint8_t             cmic;
+    uint8_t             mdts;
+    uint16_t            cntlid;
+    uint32_t            ver;
+    uint32_t            rtd3r;
+    uint32_t            rtd3e;
+    uint32_t            oaes;
+    uint32_t            ctratt;
+    uint16_t            rrls;
+    uint8_t             reservedBytes110_102[9];
+    uint8_t             cntrltype;
+    uint8_t             fguid[16];//128bit identifier
+    uint16_t            crdt1;
+    uint16_t            crdt2;
+    uint16_t            crdt3;
+    uint8_t             reservedBytes239_134[106];
+    uint8_t             nvmManagement[16];
+    //Admin command set attribues & optional controller capabilities
+    uint16_t            oacs;
+    uint8_t             acl;
+    uint8_t             aerl;
+    uint8_t             frmw;
+    uint8_t             lpa;
+    uint8_t             elpe;
+    uint8_t             npss;
+    uint8_t             avscc;
+    uint8_t             apsta;
+    uint16_t            wctemp;
+    uint16_t            cctemp;
+    uint16_t            mtfa;
+    uint32_t            hmpre;
+    uint32_t            hmmin;
+    uint8_t             tnvmcap[16];
+    uint8_t             unvmcap[16];
+    uint32_t            rpmbs;
+    uint16_t            edstt;
+    uint8_t             dsto;
+    uint8_t             fwug;
+    uint16_t            kas;
+    uint16_t            hctma;
+    uint16_t            mntmt;
+    uint16_t            mxtmt;
+    uint32_t            sanicap;
+    uint32_t            hmminds;
+    uint16_t            hmmaxd;
+    uint16_t            nsetidmax;
+    uint16_t            endgidmax;
+    uint8_t             anatt;
+    uint8_t             anacap;
+    uint32_t            anagrpmax;
+    uint32_t            nanagrpid;
+    uint32_t            pels;
+    uint16_t            domainIdentifier;
+    uint8_t             reservedBytes367_358[10];
+    uint8_t             megcap[16];
+    uint8_t             reservedBytes511_384[128];
+    //NVM command set attributes;
+    uint8_t             sqes;
+    uint8_t             cqes;
+    uint16_t            maxcmd;
+    uint32_t            nn;
+    uint16_t            oncs;
+    uint16_t            fuses;
+    uint8_t             fna;
+    uint8_t             vwc;
+    uint16_t            awun;
+    uint16_t            awupf;
+    union {
+        uint8_t             nvscc;
+        uint8_t             icsvscc;
+    };
+    uint8_t             nwpc;
+    uint16_t            acwu;
+    uint16_t            optionalCopyFormatsSupported;
+    uint32_t            sgls;
+    uint32_t            mnan;
+    uint8_t             maxdna[16];
+    uint32_t            maxcna;
+    uint8_t             reservedBytes767_564[204];
+    char                subnqn[256];
+    uint8_t             reservedBytes1791_1024[768];
+    uint8_t             nvmeOverFabrics[256];
+    nvmeIDPowerState    psd[32];
+    uint8_t             vs[1024];
+}nvmeIDCtrl;
+
+//////////////////////////////////////////
+// Functions
+//////////////////////////////////////////
+int nvme_admin_identify(char *drive);
+
+void _gen_nvme_cmd_identify(struct nvme_admin_cmd *cmd_admin, nvmeIDCtrl *data_identify_ctrl);
+int _send_nvme_cmd_admin(char *drive, struct nvme_admin_cmd *cmd_admin);
+
+
+


### PR DESCRIPTION
Adding the first NVMe-specific IDM API command, `idm_nvme_drive_lock()`.

Eventually, this command will be called by a "generic" `idm_drive_lock()` command.  However, this "generic" command is currently being used by the hardcoded scsi interface within propeller.  This will be fixed at a later date.

This PR separates the NVMe interface into a couple files:
`idm_nvme_io_admin.h\.c`  - low level functions for sending NVMe-defined "admin" commands.  Currently, only using "identify".
`idm_nvme_io.h\.c` - low level functions for sending NVMe-defined "vendor" (read "custom") commands.
`idm_nvme_api.h\.c`  - From an IDM-perspective, these are the "top" level (API) commands that are called my the higher-level lock manager.

The `idm_nvme.h\.c` files are being obsoleted and the existing functionality is being refactored into the above mentioned files.  Will delete these 2 files only after both the synchronous "read" and "write" IDM API's have been implemented.



