### PR TITLE
Feature/foss 456 add synch write idm apis

### DIFF
--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -9,20 +9,47 @@
 #ifndef __IDM_CMD_COMMON_H__
 #define __IDM_CMD_COMMON_H__
 
-//TODO: Double-check SCSI code to see if some\all of these exist already
-//      Replace as necessary
+//TODO: After NVMe implementation complete, and while updating scsi
+// code to interact with new IDM API code, replace the #defines
+// at the top of the idm.scsi.c file with this files constants
 
 #include <stdint.h>
 
 #define SUCCESS 0;
 #define FAILURE -1;
 
-#define IDM_VENDOR_CMD_DATA_LEN_BYTES   512            //TODO: Find where this is implemented on SCSI
+//TODO: Delete these 2 after nvme.c\.h are deleted.
+#define IDM_VENDOR_CMD_DATA_LEN_BYTES   512
 #define IDM_VENDOR_CMD_DATA_LEN_DWORDS  512 / 4
 
-#define IDM_LOCK_ID_LEN_BYTES   64
-#define IDM_HOST_ID_LEN_BYTES   32
-#define IDM_LVB_SIZE_MAX        8
+#define DFLT_NUM_IDM_DATA_BLOCKS    1
+
+#define IDM_LOCK_ID_LEN_BYTES       64
+#define IDM_HOST_ID_LEN_BYTES       32
+#define IDM_LVB_SIZE_MAX            8
+
+// Other idmData char array lengths
+#define IDM_DATA_RESOURCE_VER_LEN_BYTES 8
+#define IDM_DATA_RESERVED_0_LEN_BYTES   24
+#define IDM_DATA_METADATA_LEN_BYTES     64
+#define IDM_DATA_RESERVED_1_LEN_BYTES   32
+
+typedef enum _eIdmClasses {
+    IDM_MODE_UNLOCK    = 0,
+    IDM_MODE_EXCLUSIVE = 0x1,
+    IDM_MODE_SHAREABLE = 0x2,
+}eIdmClasses;
+
+typedef enum _eIdmGroups {
+    IDM_GROUP_DEFAULT = 1,
+    IDM_GROUP_INQUIRY = 0xFF,
+}eIdmGroups;
+
+typedef enum _eIdmModes {
+    IDM_CLASS_EXCLUSIVE             = 0,
+    IDM_CLASS_PROTECTED_WRITE       = 0x1,
+    IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
+}eIdmModes;
 
 typedef enum _eIdmOpcodes {
     IDM_OPCODE_NORMAL   = 0x0,
@@ -35,6 +62,13 @@ typedef enum _eIdmOpcodes {
     IDM_OPCODE_DESTROY  = 0x7,
 }eIdmOpcodes;  //NVMe CDW12 mutex opcode
 
+typedef enum _eIdmResVer {
+    IDM_RES_VER_NO_UPDATE_NO_VALID = 0,
+    IDM_RES_VER_UPDATE_NO_VALID    = 0x1,
+    IDM_RES_VER_UPDATE_VALID       = 0x2,
+    IDM_RES_VER_INVALID            = 0x3,
+}eIdmResVer;
+
 typedef enum _eIdmStates {
     IDM_STATE_UNINIT            = 0,
     IDM_STATE_LOCKED            = 0x101,
@@ -43,31 +77,6 @@ typedef enum _eIdmStates {
     IDM_STATE_TIMEOUT           = 0x104,
     IDM_STATE_DEAD              = 0xdead,
 }eIdmStates;
-
-typedef enum _eIdmModes {
-    IDM_CLASS_EXCLUSIVE             = 0,
-    IDM_CLASS_PROTECTED_WRITE       = 0x1,
-    IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
-}eIdmModes;
-
-typedef enum _eIdmClasses {
-    IDM_MODE_UNLOCK    = 0,
-    IDM_MODE_EXCLUSIVE = 0x1,
-    IDM_MODE_SHAREABLE = 0x2,
-}eIdmClasses;
-
-typedef enum _eIdmResVer {
-    IDM_RES_VER_NO_UPDATE_NO_VALID = 0,
-    IDM_RES_VER_UPDATE_NO_VALID    = 0x1,
-    IDM_RES_VER_UPDATE_VALID       = 0x2,
-    IDM_RES_VER_INVALID            = 0x3,
-}eIdmResVer;
-
-// IDM Data char array lengths
-#define IDM_DATA_RESOURCE_VER_LEN_BYTES 8
-#define IDM_DATA_RESERVED_0_LEN_BYTES   24
-#define IDM_DATA_METADATA_LEN_BYTES     64
-#define IDM_DATA_RESERVED_1_LEN_BYTES   32
 
 typedef struct _idmData {
     union {
@@ -87,8 +96,8 @@ typedef struct _idmData {
     char        host_id[IDM_HOST_ID_LEN_BYTES];
     char        rsvd1[IDM_DATA_RESERVED_1_LEN_BYTES];
     union {
-        uint64_t    rsvd2[256];      // For idm_read
-        uint64_t    ignored1[256];   // For idm_write
+        char    rsvd2[256];      // For idm_read
+        char    ignored1[256];   // For idm_write
     };
 }idmData;
 

--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -66,7 +66,6 @@ typedef enum _eIdmResVer {
 // IDM Data char array lengths
 #define IDM_DATA_RESOURCE_VER_LEN_BYTES 8
 #define IDM_DATA_RESERVED_0_LEN_BYTES   24
-#define IDM_DATA_RESOURCE_ID_LEN_BYTES  64
 #define IDM_DATA_METADATA_LEN_BYTES     64
 #define IDM_DATA_RESERVED_1_LEN_BYTES   32
 
@@ -83,7 +82,7 @@ typedef struct _idmData {
     uint64_t    class_idm;
     char        resource_ver[IDM_DATA_RESOURCE_VER_LEN_BYTES];
     char        rsvd0[IDM_DATA_RESERVED_0_LEN_BYTES];
-    char        resource_id[IDM_DATA_RESOURCE_ID_LEN_BYTES];
+    char        resource_id[IDM_LOCK_ID_LEN_BYTES];
     char        metadata[IDM_DATA_METADATA_LEN_BYTES];
     char        host_id[IDM_HOST_ID_LEN_BYTES];
     char        rsvd1[IDM_DATA_RESERVED_1_LEN_BYTES];

--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -6,22 +6,23 @@
  * idm_cmd_common.h - In-drive Mutex (IDM) related structs, enums, etc. that are common to SCSI and NVMe.
  */
 
+#ifndef __IDM_CMD_COMMON_H__
+#define __IDM_CMD_COMMON_H__
 
 //TODO: Double-check SCSI code to see if some\all of these exist already
 //      Replace as necessary
 
 #include <stdint.h>
 
-
-// #define C_CAST(type, val) (type)(val)
-
 #define SUCCESS 0;
 #define FAILURE -1;
 
-
-
 #define IDM_VENDOR_CMD_DATA_LEN_BYTES   512            //TODO: Find where this is implemented on SCSI
 #define IDM_VENDOR_CMD_DATA_LEN_DWORDS  512 / 4
+
+#define IDM_LOCK_ID_LEN_BYTES   64
+#define IDM_HOST_ID_LEN_BYTES   32
+#define IDM_LVB_SIZE_MAX        8
 
 typedef enum _eIdmOpcodes {
     IDM_OPCODE_NORMAL   = 0x0,
@@ -67,7 +68,6 @@ typedef enum _eIdmResVer {
 #define IDM_DATA_RESERVED_0_LEN_BYTES   24
 #define IDM_DATA_RESOURCE_ID_LEN_BYTES  64
 #define IDM_DATA_METADATA_LEN_BYTES     64
-#define IDM_DATA_HOST_ID_LEN_BYTES      32
 #define IDM_DATA_RESERVED_1_LEN_BYTES   32
 
 typedef struct _idmData {
@@ -85,10 +85,12 @@ typedef struct _idmData {
     char        rsvd0[IDM_DATA_RESERVED_0_LEN_BYTES];
     char        resource_id[IDM_DATA_RESOURCE_ID_LEN_BYTES];
     char        metadata[IDM_DATA_METADATA_LEN_BYTES];
-    char        host_id[IDM_DATA_HOST_ID_LEN_BYTES];
+    char        host_id[IDM_HOST_ID_LEN_BYTES];
     char        rsvd1[IDM_DATA_RESERVED_1_LEN_BYTES];
     union {
         uint64_t    rsvd2[256];      // For idm_read
         uint64_t    ignored1[256];   // For idm_write
     };
 }idmData;
+
+#endif /*__IDM_CMD_COMMON_H__ */

--- a/src/idm_nvme.c
+++ b/src/idm_nvme.c
@@ -24,7 +24,7 @@
 
 
 /**
- * gen_nvme_cmd_identify - Setup the NVMe ADmin command struct for Identify Controller (opcode=0x6)
+ * gen_nvme_cmd_identify - Setup the NVMe Admin command struct for Identify Controller (opcode=0x6)
  * @cmd_admin:          NVMe Admin Command struct to fill
  * @data_identify_ctrl: NVMe Admin Commmand data struct.  This is the cmd output destination.
  *
@@ -235,8 +235,8 @@ out:
 
 /**
  * send_nvme_cmd_idm - Send NVMe Vendor-Specific command to specified device.
- * @drive:      Drive path name.
- * @cmd_nvme:   NVMe command struct directed at the IDM firmware.
+ * @drive:    Drive path name.
+ * @cmd_nvme: Data structure for NVMe Vendor Specific Commands.
  *
   * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
 */

--- a/src/idm_nvme.c
+++ b/src/idm_nvme.c
@@ -236,11 +236,11 @@ out:
 /**
  * send_nvme_cmd_idm - Send NVMe Vendor-Specific command to specified device.
  * @drive:      Drive path name.
- * @cmd_idm:    NVMe command struct directed at the IDM firmware.
+ * @cmd_nvme:   NVMe command struct directed at the IDM firmware.
  *
   * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
 */
-int send_nvme_cmd_idm(char *drive, nvmeIdmVendorCmd *cmd_idm) {
+int send_nvme_cmd_idm(char *drive, nvmeIdmVendorCmd *cmd_nvme) {
 
     int nvme_fd;
     int ret = SUCCESS;
@@ -256,7 +256,7 @@ int send_nvme_cmd_idm(char *drive, nvmeIdmVendorCmd *cmd_idm) {
         return nvme_fd;
     }
 
-    ret = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, cmd_idm);
+    ret = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, cmd_nvme);
     if(ret) {
         #ifndef NVME_STANDALONE
         ilm_log_err("%s: ioctl failed: %d", __func__, ret);
@@ -268,7 +268,7 @@ int send_nvme_cmd_idm(char *drive, nvmeIdmVendorCmd *cmd_idm) {
 
 //TODO: Keep this debug??
     printf("%s: ioctl ret=%d\n", __func__, ret);
-    printf("%s: ioctl cmd_idm->result=%d\n", __func__, cmd_idm->result);
+    printf("%s: ioctl cmd_nvme->result=%d\n", __func__, cmd_nvme->result);
 
 //Completion Queue Entry (CQE) SIDE-NOTE:
 // CQE DW0[31:0]  == cmd_admin->result

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -58,8 +58,8 @@ int nvme_idm_break_lock(char *lock_id, int mode, char *host_id,
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
-                              mode, host_id, drive, timeout, 0, 0);
+    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, 0, 0,
+                              &request_idm, &cmd_nvme, &data_idm);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -123,8 +123,8 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id,
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
-                              mode, host_id, drive, timeout, 0, 0);
+    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, 0, 0,
+                              &request_idm, &cmd_nvme, &data_idm);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -171,8 +171,8 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id,
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
-                              mode, host_id, drive, timeout, 0, 0);
+    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, 0, 0,
+                              &request_idm, &cmd_nvme, &data_idm);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -240,8 +240,8 @@ int nvme_idm_unlock(char *lock_id, int mode, char *host_id,
     int              ret = SUCCESS;
 
      //TODO: Why 0 timeout here (ported as-is from scsi-side)?
-    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
-                              mode, host_id, drive, 0, lvb, lvb_size);
+    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0, lvb, lvb_size,
+                              &request_idm, &cmd_nvme, &data_idm);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -34,7 +34,7 @@
 //////////////////////////////////////////
 
 /**
- * idm_nvme_drive_break_lock - Break an IDM if before other hosts have
+ * nvme_idm_break_lock - Break an IDM if before other hosts have
  * acquired this IDM.  This function is to allow a host_id to take
  * over the ownership if other hosts of the IDM is timeout, or the
  * countdown value is -1UL.
@@ -46,8 +46,8 @@
  *
  * Returns zero or a negative error (ie. EINVAL).
  */
-int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id,
-                              char *drive, uint64_t timeout)
+int nvme_idm_break_lock(char *lock_id, int mode, char *host_id,
+                        char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
@@ -94,15 +94,15 @@ int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ETIME).
  */
-int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id,
-                                char *drive, uint64_t timeout)
+int nvme_idm_convert_lock(char *lock_id, int mode, char *host_id,
+                          char *drive, uint64_t timeout)
 {
-    return idm_nvme_drive_refresh_lock(lock_id, mode, host_id,
-                                       drive, timeout);
+    return nvme_idm_refresh_lock(lock_id, mode, host_id,
+                                 drive, timeout);
 }
 
 /**
- * idm_nvme_drive_lock - acquire an IDM on a specified NVMe drive
+ * nvme_idm_lock - acquire an IDM on a specified NVMe drive
  * @lock_id:     Lock ID (64 bytes).
  * @mode:        Lock mode (unlock, shareable, exclusive).
  * @host_id:     Host ID (32 bytes).
@@ -111,8 +111,8 @@ int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
-                        char *drive, uint64_t timeout)
+int nvme_idm_lock(char *lock_id, int mode, char *host_id,
+                  char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
@@ -151,7 +151,7 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
 }
 
 /**
- * idm_nvme_drive_refresh_lock - Refreshes the host's membership for an IDM
+ * nvme_idm_refresh_lock - Refreshes the host's membership for an IDM
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
  * @host_id:    Host ID (32 bytes).
@@ -159,8 +159,8 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
  * @timeout:    Timeout for membership (unit: millisecond).
  *
  * Returns zero or a negative error (ie. EINVAL, ETIME).
- */static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
-                                       char *drive, uint64_t timeout)
+ */int nvme_idm_refresh_lock(char *lock_id, int mode, char *host_id,
+                             char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
@@ -209,11 +209,11 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ETIME).
  */
-int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id,
-                              char *drive, uint64_t timeout)
+int nvme_idm_renew_lock(char *lock_id, int mode, char *host_id,
+                        char *drive, uint64_t timeout)
 {
-    return idm_nvme_drive_refresh_lock(lock_id, mode, host_id,
-                                       drive, timeout);
+    return nvme_idm_refresh_lock(lock_id, mode, host_id,
+                                 drive, timeout);
 }
 
 /**
@@ -227,8 +227,8 @@ int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ETIME).
  */
-int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id,
-                          char *lvb, int lvb_size, char *drive)
+int nvme_idm_unlock(char *lock_id, int mode, char *host_id,
+                    char *lvb, int lvb_size, char *drive)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
@@ -304,16 +304,16 @@ int main(int argc, char *argv[])
             int         lvb_size                       = 5;
 
         if(strcmp(argv[1], "break") == 0){
-            ret = idm_nvme_drive_break_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+            ret = nvme_idm_break_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
         else if(strcmp(argv[1], "lock") == 0){
-            ret = idm_nvme_drive_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+            ret = nvme_idm_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
         else if(strcmp(argv[1], "refresh") == 0){
-            ret = idm_nvme_drive_refresh_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+            ret = nvme_idm_refresh_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
         else if(strcmp(argv[1], "unlock") == 0){
-            ret = idm_nvme_drive_unlock((char*)lock_id, mode, (char*)host_id, (char*)lvb, lvb_size, drive);
+            ret = nvme_idm_unlock((char*)lock_id, mode, (char*)host_id, (char*)lvb, lvb_size, drive);
         }
         else {
             printf("%s: invalid command option!\n", argv[1]);

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <linux/nvme_ioctl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>       //TODO: Do I need BOTH ioctl includes?
 #include <unistd.h>
@@ -53,27 +54,24 @@ int nvme_idm_break_lock(char *lock_id, int mode, char *host_id,
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_nvme;
-    idmData          data_idm;
-    int              ret = SUCCESS;
+    nvmeIdmRequest *request_idm;
+    int            ret = SUCCESS;
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, 0, 0,
-                              &request_idm, &cmd_nvme, &data_idm);
-    if(ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: fail %d", __func__, ret);
-        #else
-        printf("%s: fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
+    ret = _validate_input_write(lock_id, mode, host_id, drive);
+    if (ret < 0)
         return ret;
-    }
+
+    ret = _memory_init_idm_request(&request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+    if (ret < 0)
+        return ret;
+
+    nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, request_idm);
 
     //API-specific code
-    request_idm.opcode_idm   = IDM_OPCODE_BREAK;
-    request_idm.res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
+    request_idm->opcode_idm   = IDM_OPCODE_BREAK;
+    request_idm->res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    ret = nvme_idm_write(&request_idm);
+    ret = nvme_idm_write(request_idm);
     if (ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: command fail %d", __func__, ret);
@@ -81,9 +79,11 @@ int nvme_idm_break_lock(char *lock_id, int mode, char *host_id,
         printf("%s: command fail %d\n", __func__, ret);
         #endif //COMPILE_STANDALONE
     }
+
+    _memory_free_idm_request(request_idm);
+    return ret;
 }
 
-//TODO: should this function be deprecated\removed???
 /**
  * idm_drive_convert_lock - Convert the lock mode for an IDM
  * @lock_id:    Lock ID (64 bytes).
@@ -118,27 +118,24 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id,
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_nvme;
-    idmData          data_idm;
-    int              ret = SUCCESS;
+    nvmeIdmRequest *request_idm;
+    int            ret = SUCCESS;
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, 0, 0,
-                              &request_idm, &cmd_nvme, &data_idm);
-    if(ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: fail %d", __func__, ret);
-        #else
-        printf("%s: fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
+    ret = _validate_input_write(lock_id, mode, host_id, drive);
+    if (ret < 0)
         return ret;
-    }
+
+    ret = _memory_init_idm_request(&request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+    if (ret < 0)
+        return ret;
+
+    nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, request_idm);
 
     //API-specific code
-    request_idm.opcode_idm   = IDM_OPCODE_TRYLOCK;
-    request_idm.res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
+    request_idm->opcode_idm   = IDM_OPCODE_TRYLOCK;
+    request_idm->res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    ret = nvme_idm_write(&request_idm);
+    ret = nvme_idm_write(request_idm);
     if (ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: command fail %d", __func__, ret);
@@ -147,6 +144,7 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id,
         #endif //COMPILE_STANDALONE
     }
 
+    _memory_free_idm_request(request_idm);
     return ret;
 }
 
@@ -166,27 +164,24 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id,
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_nvme;
-    idmData          data_idm;
-    int              ret = SUCCESS;
+    nvmeIdmRequest *request_idm;
+    int            ret = SUCCESS;
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, 0, 0,
-                              &request_idm, &cmd_nvme, &data_idm);
-    if(ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: fail %d", __func__, ret);
-        #else
-        printf("%s: fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
+    ret = _validate_input_write(lock_id, mode, host_id, drive);
+    if (ret < 0)
         return ret;
-    }
+
+    ret = _memory_init_idm_request(&request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+    if (ret < 0)
+        return ret;
+
+    nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, request_idm);
 
     //API-specific code
-    request_idm.opcode_idm   = IDM_OPCODE_REFRESH;
-    request_idm.res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
+    request_idm->opcode_idm   = IDM_OPCODE_REFRESH;
+    request_idm->res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    ret = nvme_idm_write(&request_idm);
+    ret = nvme_idm_write(request_idm);
     if (ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: command fail %d", __func__, ret);
@@ -195,10 +190,10 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id,
         #endif //COMPILE_STANDALONE
     }
 
+    _memory_free_idm_request(request_idm);
     return ret;
 }
 
-//TODO: should this function be deprecated\removed???
 /**
  * idm_drive_renew_lock - Renew host's membership for an IDM
  * @lock_id:    Lock ID (64 bytes).
@@ -234,28 +229,32 @@ int nvme_idm_unlock(char *lock_id, int mode, char *host_id,
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_nvme;
-    idmData          data_idm;
-    int              ret = SUCCESS;
+    nvmeIdmRequest *request_idm;
+    int            ret = SUCCESS;
+
+    ret = _validate_input_write(lock_id, mode, host_id, drive);
+    if (ret < 0)
+        return ret;
+
+    //TODO: The -ve check here should go away cuz lvb_size should be of unsigned type.
+    //However, this requires an IDM API parameter type change.
+    if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_SIZE_MAX))
+        return -EINVAL;
+
+    ret = _memory_init_idm_request(&request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+    if (ret < 0)
+        return ret;
 
      //TODO: Why 0 timeout here (ported as-is from scsi-side)?
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0, lvb, lvb_size,
-                              &request_idm, &cmd_nvme, &data_idm);
-    if(ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: fail %d", __func__, ret);
-        #else
-        printf("%s: fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+    nvme_idm_write_init(lock_id, mode, host_id, drive, 0, request_idm);
 
     //API-specific code
-    request_idm.opcode_idm   = IDM_OPCODE_UNLOCK;
-    request_idm.res_ver_type = IDM_RES_VER_UPDATE_NO_VALID;
+    request_idm->lvb          = lvb;
+    request_idm->lvb_size     = lvb_size;
+    request_idm->opcode_idm   = IDM_OPCODE_UNLOCK;
+    request_idm->res_ver_type = IDM_RES_VER_UPDATE_NO_VALID;
 
-    ret = nvme_idm_write(&request_idm);
+    ret = nvme_idm_write(request_idm);
     if (ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: command fail %d", __func__, ret);
@@ -264,8 +263,141 @@ int nvme_idm_unlock(char *lock_id, int mode, char *host_id,
         #endif //COMPILE_STANDALONE
     }
 
+    _memory_free_idm_request(request_idm);
     return ret;
 }
+
+/**
+ * _memory_free_idm_request - Convenience function for freeing memory for all the
+ *                            data structures used during the NVMe command sequence.
+ *
+ * @request_idm: Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+void _memory_free_idm_request(nvmeIdmRequest *request_idm) {
+
+    #ifdef FUNCTION_ENTRY_DEBUG
+    printf("%s: START\n", __func__);
+    #endif //FUNCTION_ENTRY_DEBUG
+
+    free(request_idm->data_idm);
+    free(request_idm);
+}
+
+/**
+ * _memory_init_idm_request - Convenience function for allocating memory for all the
+ *                            data structures used during the NVMe command sequence.
+ *
+ * @request_idm: Struct containing all NVMe-specific command info for the requested IDM action.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int _memory_init_idm_request(nvmeIdmRequest **request_idm, unsigned int data_num) {
+
+    #ifdef FUNCTION_ENTRY_DEBUG
+    printf("%s: START\n", __func__);
+    #endif //FUNCTION_ENTRY_DEBUG
+
+    int data_len;
+
+    *request_idm = malloc(sizeof(nvmeIdmRequest));
+    if (!request_idm) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: request memory allocate fail", __func__);
+        #else
+        printf("%s: request memory allocate fail\n", __func__);
+        #endif //COMPILE_STANDALONE
+        return -ENOMEM;
+    }
+    memset((*request_idm), 0, sizeof(**request_idm));
+
+    data_len                 = sizeof(idmData) * data_num;
+    (*request_idm)->data_idm = malloc(data_len);
+    if (!(*request_idm)->data_idm) {
+        free((*request_idm));
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: request data memory allocate fail", __func__);
+        #else
+        printf("%s: request data memory allocate fail\n", __func__);
+        #endif //COMPILE_STANDALONE
+        return -ENOMEM;
+    }
+    memset((*request_idm)->data_idm, 0, data_len);
+
+    printf("%s: (*request_idm)=%u\n", __func__, (*request_idm));
+    printf("%s: size=%u\n", __func__, sizeof(**request_idm));
+    printf("%s: (*request_idm)->data_idm=%u\n", __func__, (*request_idm)->data_idm);
+    printf("%s: size=%u\n", __func__, sizeof(*(*request_idm)->data_idm));
+    // printf("%s: (*request_idm).cmd_nvme=%u\n", __func__, (*request_idm).cmd_nvme);
+    // printf("%s: size=%u\n", __func__, sizeof((*request_idm)->cmd_nvme));
+
+    //Cache params.  Not really related to func, but convenient.
+    (*request_idm)->data_len = data_len;
+    (*request_idm)->data_num = data_num;
+    printf("%s: (*request_idm)->data_len=%u\n", __func__, (*request_idm)->data_len);
+
+    return SUCCESS;
+}
+
+/**
+ * _validate_input_common - Convenience function for validating the most common
+ *                          IDM API input parameters.
+ *
+ * @lock_id:        Lock ID (64 bytes).
+ * @host_id:        Host ID (32 bytes).
+ * @drive:          Drive path name.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int _validate_input_common(char *lock_id, char *host_id, char *drive) {
+
+    #ifdef FUNCTION_ENTRY_DEBUG
+    printf("%s: START\n", __func__);
+    #endif //FUNCTION_ENTRY_DEBUG
+
+    int ret = SUCCESS;
+
+    #ifndef COMPILE_STANDALONE
+    if (ilm_inject_fault_is_hit())
+        return -EIO;
+    #endif //COMPILE_STANDALONE
+
+    if (!lock_id || !host_id || !drive)
+        return -EINVAL;
+
+//TODO: Add general check for "mode" here? (ie: a valid enum value)
+
+    return ret;
+}
+
+/**
+ * _validate_input_common - Convenience function for validating the most common
+ *                          IDM API input parameters used during an IDM write cmd.
+ *
+ * @lock_id:        Lock ID (64 bytes).
+ * @mode:           Lock mode (unlock, shareable, exclusive).
+ * @host_id:        Host ID (32 bytes).
+ * @drive:          Drive path name.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive) {
+
+    #ifdef FUNCTION_ENTRY_DEBUG
+    printf("%s: START\n", __func__);
+    #endif //FUNCTION_ENTRY_DEBUG
+
+    int ret = SUCCESS;
+
+    ret = _validate_input_common(lock_id, host_id, drive);
+
+    if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
+        return -EINVAL;
+
+    return ret;
+}
+
 
 
 
@@ -296,21 +428,27 @@ int main(int argc, char *argv[])
 
     //cli usage: idm_nvme_api lock
     if(argc >= 2){
-            char        lock_id[IDM_HOST_ID_LEN_BYTES] = "lock_id";
-            int         mode                           = IDM_MODE_EXCLUSIVE;
-            char        host_id[IDM_LOCK_ID_LEN_BYTES] = "host_id";
-            uint64_t    timeout                        = 10;
-            char        lvb[IDM_LVB_SIZE_MAX]          = "lvb";
-            int         lvb_size                       = 5;
+        char        lock_id[IDM_HOST_ID_LEN_BYTES] = "lock_id";
+        int         mode                           = IDM_MODE_EXCLUSIVE;
+        char        host_id[IDM_LOCK_ID_LEN_BYTES] = "host_id";
+        uint64_t    timeout                        = 10;
+        char        lvb[IDM_LVB_SIZE_MAX]          = "lvb";
+        int         lvb_size                       = 5;
 
         if(strcmp(argv[1], "break") == 0){
             ret = nvme_idm_break_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+        }
+        else if(strcmp(argv[1], "convert") == 0){
+            ret = nvme_idm_convert_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
         else if(strcmp(argv[1], "lock") == 0){
             ret = nvme_idm_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
         else if(strcmp(argv[1], "refresh") == 0){
             ret = nvme_idm_refresh_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+        }
+        else if(strcmp(argv[1], "renew") == 0){
+            ret = nvme_idm_renew_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
         else if(strcmp(argv[1], "unlock") == 0){
             ret = nvme_idm_unlock((char*)lock_id, mode, (char*)host_id, (char*)lvb, lvb_size, drive);

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -29,6 +29,68 @@
 //////////////////////////////////////////
 // FUNCTIONS
 //////////////////////////////////////////
+
+
+/**
+ * idm_nvme_drive_break_lock - Break an IDM if before other hosts have
+ * acquired this IDM.  This function is to allow a host_id to take
+ * over the ownership if other hosts of the IDM is timeout, or the
+ * countdown value is -1UL.
+ * @lock_id:    Lock ID (64 bytes).
+ * @mode:       Lock mode (unlock, shareable, exclusive).
+ * @host_id:    Host ID (32 bytes).
+ * @drive:      Drive path name.
+ * @timeout:    Timeout for membership (unit: millisecond).
+ *
+ * Returns zero or a negative error (ie. EINVAL).
+ */
+int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout)
+{
+    printf("%s: START\n", __func__);
+
+//TODO: Should I be using malloc() instead?
+    nvmeIdmRequest   request_idm;
+    nvmeIdmVendorCmd cmd_idm;
+    idmData          data_idm;
+    int              ret = SUCCESS;
+
+    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
+                              lock_id, mode, host_id, drive, timeout, 0, 0);
+    if(ret < 0) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: fail %d", __func__, ret);
+        #else
+        printf("%s: fail %d\n", __func__, ret);
+        #endif //COMPILE_STANDALONE
+        return ret;
+    }
+
+    //API-specific code
+    switch(mode) {
+        case IDM_MODE_EXCLUSIVE:
+            request_idm.class_idm = IDM_CLASS_EXCLUSIVE;
+        case IDM_MODE_SHAREABLE:
+            request_idm.class_idm = IDM_CLASS_SHARED_PROTECTED_READ;
+        default:
+//TODO: This case is the resultant default behavior of the equivalent scsi code.  Does this make sense???
+//          Talk to Tom about this.
+//          Feels like this should be an error
+            request_idm.class_idm = mode;
+    }
+
+    request_idm.opcode_idm   = IDM_OPCODE_BREAK;
+    request_idm.res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
+
+    ret = nvme_idm_write(&request_idm);
+    if (ret < 0) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: command fail %d", __func__, ret);
+        #else
+        printf("%s: command fail %d\n", __func__, ret);
+        #endif //COMPILE_STANDALONE
+    }
+}
+
 /**
  * idm_nvme_drive_lock - acquire an IDM on a specified NVMe drive
  * @lock_id:     Lock ID (64 bytes).
@@ -39,8 +101,8 @@
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout) {
-
+int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout)
+{
     printf("%s: START\n", __func__);
 
 //TODO: Should I be using malloc() instead?
@@ -49,28 +111,18 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
     idmData          data_idm;
     int              ret = SUCCESS;
 
-//TODO: Common function for init error checking???
-    #ifndef COMPILE_STANDALONE
-    if (ilm_inject_fault_is_hit())
-        return -EIO;
-    #endif //COMPILE_STANDALONE
+    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
+                              lock_id, mode, host_id, drive, timeout, 0, 0);
+    if(ret < 0) {
+        #ifndef COMPILE_STANDALONE
+        ilm_log_err("%s: fail %d", __func__, ret);
+        #else
+        printf("%s: fail %d\n", __func__, ret);
+        #endif //COMPILE_STANDALONE
+        return ret;
+    }
 
-    if (!lock_id || !host_id || !drive)
-        return -EINVAL;
-
-    if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
-        return -EINVAL;
-
-    nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
-                        lock_id, mode, host_id,drive, timeout, 0, 0);
-
-//TODO: Remove this comment
-	// if (mode == IDM_MODE_EXCLUSIVE)
-	// 	mode = IDM_CLASS_EXCLUSIVE;
-	// else if (mode == IDM_MODE_SHAREABLE)
-	// 	mode = IDM_CLASS_SHARED_PROTECTED_READ;
-
-//Start API-specific settings
+    //API-specific code
     switch(mode) {
         case IDM_MODE_EXCLUSIVE:
             request_idm.class_idm = IDM_CLASS_EXCLUSIVE;
@@ -85,18 +137,212 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
 
     request_idm.opcode_idm   = IDM_OPCODE_TRYLOCK;
     request_idm.res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
-    request_idm.data_len     = sizeof(idmData);         //TODO: review this.  This can happen later
 
     ret = nvme_idm_write(&request_idm);
-    if (ret < 0)
+    if (ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: command fail %d", __func__, ret);
         #else
         printf("%s: command fail %d\n", __func__, ret);
         #endif //COMPILE_STANDALONE
+    }
 
     return ret;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// /**
+//  * idm_drive_unlock - release an IDM on a specified drive
+//  * @lock_id:    Lock ID (64 bytes).
+//  * @mode:       Lock mode (unlock, shareable, exclusive).
+//  * @host_id:    Host ID (32 bytes).
+//  * @lvb:        Lock value block pointer.
+//  * @lvb_size:   Lock value block size.
+//  * @drive:      Drive path name.
+//  *
+//  * Returns zero or a negative error (ie. EINVAL, ETIME).
+//  */
+// int idm_drive_unlock(char *lock_id, int mode, char *host_id,
+//              char *lvb, int lvb_size, char *drive)
+// {
+//     struct idm_scsi_request *request;
+//     int ret;
+
+//     if (ilm_inject_fault_is_hit())
+//         return -EIO;
+
+//     if (!lock_id || !host_id || !drive)
+//         return -EINVAL;
+
+//     if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
+//         return -EINVAL;
+
+//     if (lvb_size > IDM_VALUE_LEN)
+//         return -EINVAL;
+
+//     request = malloc(sizeof(struct idm_scsi_request));
+//     if (!request) {
+//         ilm_log_err("%s: fail to allocat scsi request", __func__);
+//         return -ENOMEM;
+//     }
+//     memset(request, 0x0, sizeof(struct idm_scsi_request));
+
+//     request->data = malloc(sizeof(struct idm_data));
+//     if (!request->data) {
+//         free(request);
+//         ilm_log_err("%s: fail to allocat scsi data", __func__);
+//         return -ENOMEM;
+//     }
+//     memset(request->data, 0x0, sizeof(struct idm_data));
+
+//     if (mode == IDM_MODE_EXCLUSIVE)
+//         mode = IDM_CLASS_EXCLUSIVE;
+//     else if (mode == IDM_MODE_SHAREABLE)
+//         mode = IDM_CLASS_SHARED_PROTECTED_READ;
+
+//     strncpy(request->drive, drive, PATH_MAX);
+//     request->op = IDM_MUTEX_OP_UNLOCK;
+//     request->mode = mode;
+//     request->timeout = 0;
+//     request->data_len = sizeof(struct idm_data);
+//     request->res_ver_type = IDM_RES_VER_UPDATE_NO_VALID;
+//     memcpy(request->lock_id, lock_id, IDM_LOCK_ID_LEN);
+//     memcpy(request->host_id, host_id, IDM_HOST_ID_LEN);
+//     memcpy(request->lvb, lvb, lvb_size);
+
+//     ret = _scsi_xfer_sync(request);
+//     if (ret < 0)
+//         ilm_log_err("%s: command fail %d", __func__, ret);
+
+//     free(request->data);
+//     free(request);
+//     return ret;
+// }
+
+// static int idm_drive_refresh_lock(char *lock_id, int mode, char *host_id,
+//                   char *drive, uint64_t timeout)
+// {
+//     struct idm_scsi_request *request;
+//     int ret;
+
+//     if (ilm_inject_fault_is_hit())
+//         return -EIO;
+
+//     if (!lock_id || !host_id || !drive)
+//         return -EINVAL;
+
+//     if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
+//         return -EINVAL;
+
+//     request = malloc(sizeof(struct idm_scsi_request));
+//     if (!request) {
+//         ilm_log_err("%s: fail to allocat scsi request", __func__);
+//         return -ENOMEM;
+//     }
+//     memset(request, 0x0, sizeof(struct idm_scsi_request));
+
+//     request->data = malloc(sizeof(struct idm_data));
+//     if (!request->data) {
+//         free(request);
+//         ilm_log_err("%s: fail to allocat scsi data", __func__);
+//         return -ENOMEM;
+//     }
+//     memset(request->data, 0x0, sizeof(struct idm_data));
+
+//     if (mode == IDM_MODE_EXCLUSIVE)
+//         mode = IDM_CLASS_EXCLUSIVE;
+//     else if (mode == IDM_MODE_SHAREABLE)
+//         mode = IDM_CLASS_SHARED_PROTECTED_READ;
+
+//     strncpy(request->drive, drive, PATH_MAX);
+//     request->op = IDM_MUTEX_OP_REFRESH;
+//     request->mode = mode;
+//     request->timeout = timeout;
+//     request->res_ver_type = IDM_RES_VER_NO_UPDATE_NO_VALID;
+//     request->data_len = sizeof(struct idm_data);
+//     memcpy(request->lock_id, lock_id, IDM_LOCK_ID_LEN);
+//     memcpy(request->host_id, host_id, IDM_HOST_ID_LEN);
+
+//     ret = _scsi_xfer_sync(request);
+//     if (ret < 0)
+//         ilm_log_err("%s: command fail %d", __func__, ret);
+
+//     free(request->data);
+//     free(request);
+//     return ret;
+// }
+
+// /**
+//  * idm_drive_convert_lock - Convert the lock mode for an IDM
+//  * @lock_id:    Lock ID (64 bytes).
+//  * @mode:       Lock mode (unlock, shareable, exclusive).
+//  * @host_id:    Host ID (32 bytes).
+//  * @drive:      Drive path name.
+//  * @timeout:    Timeout for membership (unit: millisecond).
+//  *
+//  * Returns zero or a negative error (ie. EINVAL, ETIME).
+//  */
+// int idm_drive_convert_lock(char *lock_id, int mode, char *host_id,
+//                char *drive, uint64_t timeout)
+// {
+//     return idm_drive_refresh_lock(lock_id, mode, host_id,
+//                       drive, timeout);
+// }
+
+// /**
+//  * idm_drive_renew_lock - Renew host's membership for an IDM
+//  * @lock_id:    Lock ID (64 bytes).
+//  * @mode:       Lock mode (unlock, shareable, exclusive).
+//  * @host_id:    Host ID (32 bytes).
+//  * @drive:      Drive path name.
+//  * @timeout:    Timeout for membership (unit: millisecond).
+//  *
+//  * Returns zero or a negative error (ie. EINVAL, ETIME).
+//  */
+// int idm_drive_renew_lock(char *lock_id, int mode, char *host_id,
+//              char *drive, uint64_t timeout)
+// {
+//     return idm_drive_refresh_lock(lock_id, mode, host_id,
+//                       drive, timeout);
+// }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -108,7 +354,7 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
 #define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1";
 
 //To compile:
-//gcc idm_nvme_api.c -o idm_nvme_api
+//gcc idm_nvme_io.c idm_nvme_api.c -o idm_nvme_api
 int main(int argc, char *argv[])
 {
     char *drive;
@@ -123,17 +369,22 @@ int main(int argc, char *argv[])
 
     //cli usage: idm_nvme_api lock
     if(argc >= 2){
-        if(strcmp(argv[1], "lock") == 0){
             char        lock_id[64] = "lock_id";
             int         mode        = IDM_MODE_EXCLUSIVE;
             char        host_id[32] = "host_id";
             uint64_t    timeout     = 10;
-            ret = idm_nvme_drive_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
-            printf("%s exiting with %d\n", argv[1], ret);
+        if(strcmp(argv[1], "break") == 0){
+            ret = idm_nvme_drive_break_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
         }
-
+        else if(strcmp(argv[1], "lock") == 0){
+            ret = idm_nvme_drive_lock((char*)lock_id, mode, (char*)host_id, drive, timeout);
+        }
+        printf("%s exiting with %d\n", argv[1], ret);
+    }
+    else{
+        printf("No command option given\n");
     }
 
-    return 0;
+    return ret;
 }
 #endif//MAIN_ACTIVATE

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -54,11 +54,11 @@ int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id,
     #endif //FUNCTION_ENTRY_DEBUG
 
     nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_idm;
+    nvmeIdmVendorCmd cmd_nvme;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
                               mode, host_id, drive, timeout, 0, 0);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
@@ -119,11 +119,11 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
     #endif //FUNCTION_ENTRY_DEBUG
 
     nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_idm;
+    nvmeIdmVendorCmd cmd_nvme;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
                               mode, host_id, drive, timeout, 0, 0);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
@@ -159,11 +159,11 @@ static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
     #endif //FUNCTION_ENTRY_DEBUG
 
     nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_idm;
+    nvmeIdmVendorCmd cmd_nvme;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
                               mode, host_id, drive, timeout, 0, 0);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
@@ -227,11 +227,11 @@ int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id,
     #endif //FUNCTION_ENTRY_DEBUG
 
     nvmeIdmRequest   request_idm;
-    nvmeIdmVendorCmd cmd_idm;
+    nvmeIdmVendorCmd cmd_nvme;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+    ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
                               mode, host_id, drive, 0, lvb, lvb_size); //TODO: Why 0 timeout here?
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -27,6 +27,7 @@
 
 #define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
 
+//TODO: Should I be using malloc() instead of declaring the struct objects at the top of each idm api???
 
 //////////////////////////////////////////
 // FUNCTIONS
@@ -45,21 +46,20 @@
  *
  * Returns zero or a negative error (ie. EINVAL).
  */
-int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive,
-                              uint64_t timeout)
+int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id,
+                              char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-//TODO: Should I be using malloc() instead?
     nvmeIdmRequest   request_idm;
     nvmeIdmVendorCmd cmd_idm;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
-                              lock_id, mode, host_id, drive, timeout, 0, 0);
+    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+                              mode, host_id, drive, timeout, 0, 0);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -83,6 +83,24 @@ int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *driv
     }
 }
 
+//TODO: should this function be deprecated\removed???
+/**
+ * idm_drive_convert_lock - Convert the lock mode for an IDM
+ * @lock_id:    Lock ID (64 bytes).
+ * @mode:       Lock mode (unlock, shareable, exclusive).
+ * @host_id:    Host ID (32 bytes).
+ * @drive:      Drive path name.
+ * @timeout:    Timeout for membership (unit: millisecond).
+ *
+ * Returns zero or a negative error (ie. EINVAL, ETIME).
+ */
+int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id,
+                                char *drive, uint64_t timeout)
+{
+    return idm_nvme_drive_refresh_lock(lock_id, mode, host_id,
+                                       drive, timeout);
+}
+
 /**
  * idm_nvme_drive_lock - acquire an IDM on a specified NVMe drive
  * @lock_id:     Lock ID (64 bytes).
@@ -93,20 +111,20 @@ int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *driv
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout)
+int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
+                        char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-//TODO: Should I be using malloc() instead?
     nvmeIdmRequest   request_idm;
     nvmeIdmVendorCmd cmd_idm;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
-                              lock_id, mode, host_id, drive, timeout, 0, 0);
+    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+                              mode, host_id, drive, timeout, 0, 0);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -133,21 +151,20 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
 }
 
 //TODO: docstring
-static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id, char *drive,
-                                       uint64_t timeout)
+static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
+                                       char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-//TODO: Should I be using malloc() instead?
     nvmeIdmRequest   request_idm;
     nvmeIdmVendorCmd cmd_idm;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
-                              lock_id, mode, host_id, drive, timeout, 0, 0);
+    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+                              mode, host_id, drive, timeout, 0, 0);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -173,6 +190,24 @@ static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id, c
     return ret;
 }
 
+//TODO: should this function be deprecated\removed???
+/**
+ * idm_drive_renew_lock - Renew host's membership for an IDM
+ * @lock_id:    Lock ID (64 bytes).
+ * @mode:       Lock mode (unlock, shareable, exclusive).
+ * @host_id:    Host ID (32 bytes).
+ * @drive:      Drive path name.
+ * @timeout:    Timeout for membership (unit: millisecond).
+ *
+ * Returns zero or a negative error (ie. EINVAL, ETIME).
+ */
+int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id,
+                              char *drive, uint64_t timeout)
+{
+    return idm_nvme_drive_refresh_lock(lock_id, mode, host_id,
+                                       drive, timeout);
+}
+
 /**
  * idm_drive_unlock - release an IDM on a specified drive
  * @lock_id:    Lock ID (64 bytes).
@@ -191,14 +226,13 @@ int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id,
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-//TODO: Should I be using malloc() instead?
     nvmeIdmRequest   request_idm;
     nvmeIdmVendorCmd cmd_idm;
     idmData          data_idm;
     int              ret = SUCCESS;
 
-    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm,
-                              lock_id, mode, host_id, drive, 0, lvb, lvb_size); //TODO: Why 0 timeout here?
+    ret = nvme_idm_write_init(&request_idm, &cmd_idm, &data_idm, lock_id,
+                              mode, host_id, drive, 0, lvb, lvb_size); //TODO: Why 0 timeout here?
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);
@@ -223,70 +257,6 @@ int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id,
 
     return ret;
 }
-
-
-
-
-
-
-
-//TODO: should "convert" and "renew" be deprecated\removed???
-
-// /**
-//  * idm_drive_convert_lock - Convert the lock mode for an IDM
-//  * @lock_id:    Lock ID (64 bytes).
-//  * @mode:       Lock mode (unlock, shareable, exclusive).
-//  * @host_id:    Host ID (32 bytes).
-//  * @drive:      Drive path name.
-//  * @timeout:    Timeout for membership (unit: millisecond).
-//  *
-//  * Returns zero or a negative error (ie. EINVAL, ETIME).
-//  */
-// int idm_drive_convert_lock(char *lock_id, int mode, char *host_id,
-//                char *drive, uint64_t timeout)
-// {
-//     return idm_drive_refresh_lock(lock_id, mode, host_id,
-//                       drive, timeout);
-// }
-
-
-
-// /**
-//  * idm_drive_renew_lock - Renew host's membership for an IDM
-//  * @lock_id:    Lock ID (64 bytes).
-//  * @mode:       Lock mode (unlock, shareable, exclusive).
-//  * @host_id:    Host ID (32 bytes).
-//  * @drive:      Drive path name.
-//  * @timeout:    Timeout for membership (unit: millisecond).
-//  *
-//  * Returns zero or a negative error (ie. EINVAL, ETIME).
-//  */
-// int idm_drive_renew_lock(char *lock_id, int mode, char *host_id,
-//              char *drive, uint64_t timeout)
-// {
-//     return idm_drive_refresh_lock(lock_id, mode, host_id,
-//                       drive, timeout);
-// }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -150,8 +150,16 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id,
     return ret;
 }
 
-//TODO: docstring
-static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
+/**
+ * idm_nvme_drive_refresh_lock - Refreshes the host's membership for an IDM
+ * @lock_id:    Lock ID (64 bytes).
+ * @mode:       Lock mode (unlock, shareable, exclusive).
+ * @host_id:    Host ID (32 bytes).
+ * @drive:      Drive path name.
+ * @timeout:    Timeout for membership (unit: millisecond).
+ *
+ * Returns zero or a negative error (ie. EINVAL, ETIME).
+ */static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
                                        char *drive, uint64_t timeout)
 {
     #ifdef FUNCTION_ENTRY_DEBUG
@@ -231,8 +239,9 @@ int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id,
     idmData          data_idm;
     int              ret = SUCCESS;
 
+     //TODO: Why 0 timeout here (ported as-is from scsi-side)?
     ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm, lock_id,
-                              mode, host_id, drive, 0, lvb, lvb_size); //TODO: Why 0 timeout here?
+                              mode, host_id, drive, 0, lvb, lvb_size);
     if(ret < 0) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: fail %d", __func__, ret);

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -15,6 +15,7 @@
 int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+//TODO: Why is this static (as ported from scsi-side)?  Remove static?
 static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
                                        char *drive, uint64_t timeout);
 int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -13,11 +13,11 @@
 
 
 int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-//int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
                                        char *drive, uint64_t timeout);
-// int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
 
 #endif /*__IDM_NVME_API_H__ */

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -11,6 +11,8 @@
 
 #include <stdint.h>
 
+#include "idm_nvme_io.h"
+
 
 int nvme_idm_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int nvme_idm_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
@@ -18,5 +20,9 @@ int nvme_idm_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t 
 int nvme_idm_refresh_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int nvme_idm_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int nvme_idm_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
+void _memory_free_idm_request(nvmeIdmRequest *request_idm);
+int _memory_init_idm_request(nvmeIdmRequest **request_idm, unsigned int data_num);
+int _validate_input_common(char *lock_id, char *host_id, char *drive);
+int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive);
 
 #endif /*__IDM_NVME_API_H__ */

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -12,13 +12,11 @@
 #include <stdint.h>
 
 
-int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-//TODO: Why is this static (as ported from scsi-side)?  Remove static?
-static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
-                                       char *drive, uint64_t timeout);
-int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
+int nvme_idm_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_refresh_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
 
 #endif /*__IDM_NVME_API_H__ */

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -6,6 +6,9 @@
  * idm_nvme_api.h - Primary NVMe interface for the In-drive Mutex (IDM)
   */
 
+#ifndef __IDM_NVME_API_H__
+#define __IDM_NVME_API_H__
+
 #include <stdint.h>
 
 
@@ -15,4 +18,6 @@ int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uin
 static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
                                        char *drive, uint64_t timeout);
 // int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-// int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
+int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
+
+#endif /*__IDM_NVME_API_H__ */

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -9,5 +9,8 @@
 #include <stdint.h>
 
 
+int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-
+int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -10,7 +10,9 @@
 
 
 int idm_nvme_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+//int idm_nvme_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int idm_nvme_drive_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
+static int idm_nvme_drive_refresh_lock(char *lock_id, int mode, char *host_id,
+                                       char *drive, uint64_t timeout);
+// int idm_nvme_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+// int idm_nvme_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -84,9 +84,6 @@ EXIT_NVME_IDM_WRITE:
                          for use later (but before the NVMe write command is sent to the OS kernel).
  *                       Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- * @cmd_nvme:       Data structure for NVMe Vendor Specific Commands.
- * @data_idm:       Data structure for sending and receiving IDM-specifc data.
  * @lock_id:        Lock ID (64 bytes).
  * @mode:           Lock mode (unlock, shareable, exclusive).
  * @host_id:        Host ID (32 bytes).
@@ -96,12 +93,16 @@ EXIT_NVME_IDM_WRITE:
  *                  If not used, set to 0.      //kludge
  * @lvb_size:       Lock value block size.
  *                  If not used, set to 0.      //kludge
+ * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @cmd_nvme:       Data structure for NVMe Vendor Specific Commands.
+ * @data_idm:       Data structure for sending and receiving IDM-specifc data.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
-                        idmData *data_idm, char *lock_id, int mode, char *host_id,
-                        char *drive, uint64_t timeout, char *lvb, int lvb_size) {
+int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
+                        uint64_t timeout, char *lvb, int lvb_size,
+                        nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
+                        idmData *data_idm) {
 
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
@@ -481,8 +482,8 @@ int main(int argc, char *argv[])
             idmData          data_idm;
             int              ret = SUCCESS;
 
-            ret = nvme_idm_write_init(&request_idm, &cmd_nvme, &data_idm,
-                                      lock_id, mode, host_id,drive, timeout, 0, 0);
+            ret = nvme_idm_write_init(lock_id, mode, host_id,drive, timeout, 0, 0,
+                                      &request_idm, &cmd_nvme, &data_idm);
             printf("%s exiting with %d\n", argv[1], ret);
 
             ret = nvme_idm_write(&request_idm);

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -85,8 +85,8 @@ EXIT_NVME_IDM_WRITE:
  *                       Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
  * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- * @cmd_nvme:       NVMe Vendor Specific Command command word data structure.
- * @data_idm:       Data structure for sending and receiving IDM-speicifc data.
+ * @cmd_nvme:       Data structure for NVMe Vendor Specific Commands.
+ * @data_idm:       Data structure for sending and receiving IDM-specifc data.
  * @lock_id:        Lock ID (64 bytes).
  * @mode:           Lock mode (unlock, shareable, exclusive).
  * @host_id:        Host ID (32 bytes).

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -180,7 +180,7 @@ int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme) {
 //TODO: Change spec so don't have to do this 4-bit shift
     cmd_idm->opcode_idm_bits7_4 = request_idm->opcode_idm << 4;
     cmd_idm->group_idm          = request_idm->group_idm;       //TODO: This isn't yet getting set anywhere for lock
-    cmd_idm->timeout_ms         = VENDOR_CMD_TIMEOUT_DEFAULT;  //TODO: ??  THis vs the timout param passed in??
+    cmd_idm->timeout_ms         = VENDOR_CMD_TIMEOUT_DEFAULT;
 
     return ret;
 }
@@ -298,7 +298,7 @@ int _nvme_idm_cmd_status_check(int status, int opcode_idm) {
 
     int ret;
 
-//TODO: can NOT decipher hardcoded SCSI "Sense" data in Propeller NVMe spec
+//TODO: Unable to decipher hardcoded SCSI "Sense" data to translate to Propeller NVMe spec
     switch(status) {
         case NVME_IDM_ERR_MUTEX_OP_FAILURE:
             ret = -EINVAL;

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "idm_nvme_io.h"
+#include "idm_nvme_utils.h"
 
 
 //////////////////////////////////////////
@@ -84,8 +85,8 @@ EXIT_NVME_IDM_WRITE:
  *                       Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
  * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- * @cmd_nvme:       NVMe Vendor Specific Command command word data structure
- * @data_idm:       IDM-specific data structure
+ * @cmd_nvme:       NVMe Vendor Specific Command command word data structure.
+ * @data_idm:       Data structure for sending and receiving IDM-speicifc data.
  * @lock_id:        Lock ID (64 bytes).
  * @mode:           Lock mode (unlock, shareable, exclusive).
  * @host_id:        Host ID (32 bytes).
@@ -239,6 +240,10 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
         #endif //COMPILE_STANDALONE
         return nvme_fd;
     }
+
+    //TODO: Put this under a debug flag of some kind??
+    dumpNvmeCmdStruct(request_idm->cmd_nvme, 1, 1);
+    dumpIdmDataStruct(request_idm->data_idm);
 
     status_ioctl = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, request_idm->cmd_nvme);
     if(status_ioctl) {

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -47,41 +47,30 @@ int nvme_idm_write(nvmeIdmRequest *request_idm) {
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmVendorCmd *cmd_nvme = request_idm->cmd_nvme;
-    idmData *data_idm          = request_idm->data_idm;
-    int ret                    = SUCCESS;
+    int ret = SUCCESS;
 
-    ret = _nvme_idm_cmd_init_wrt(request_idm);
+    ret = _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
     if(ret < 0) {
-        goto EXIT_NVME_IDM_WRITE;
+        return ret;
     }
 
     ret = _nvme_idm_data_init_wrt(request_idm);
     if(ret < 0) {
-        goto EXIT_NVME_IDM_WRITE;
+        return ret;
     }
-
-    #ifndef COMPILE_STANDALONE
-	ilm_log_array_dbg("resource_ver", data_idm->resource_ver, IDM_DATA_RESOURCE_VER_LEN_BYTES);
-    #endif
 
     ret = _nvme_idm_cmd_send(request_idm);
     if(ret < 0) {
-        goto EXIT_NVME_IDM_WRITE;
+        return ret;
     }
 
-//TODO: what do with this debug code?
-    printf("%s: data_idm_write.resource_id = %s\n", __func__, data_idm->resource_id);
-    printf("%s: data_idm_write.time_now = %s\n"   , __func__, data_idm->time_now);
-
-EXIT_NVME_IDM_WRITE:
     return ret;
 }
 
 /**
  * nvme_idm_write_init - Initializes an NVMe write to the IDM by validating and then collecting all
-*                        the IDM API input params and storing them in the "request_idm" data struct
-                         for use later (but before the NVMe write command is sent to the OS kernel).
+ *                       the IDM API input params and storing them in the "request_idm" data struct
+ *                       for use later (but before the NVMe write command is sent to the OS kernel).
  *                       Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
  * @lock_id:        Lock ID (64 bytes).
@@ -89,41 +78,26 @@ EXIT_NVME_IDM_WRITE:
  * @host_id:        Host ID (32 bytes).
  * @drive:          Drive path name.
  * @timeout:        Timeout for membership (unit: millisecond).
- * @lvb:            Lock value block pointer.
- *                  If not used, set to 0.      //kludge
- * @lvb_size:       Lock value block size.
- *                  If not used, set to 0.      //kludge
  * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- * @cmd_nvme:       Data structure for NVMe Vendor Specific Commands.
- * @data_idm:       Data structure for sending and receiving IDM-specifc data.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
-                        uint64_t timeout, char *lvb, int lvb_size,
-                        nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
-                        idmData *data_idm) {
+                        uint64_t timeout, nvmeIdmRequest *request_idm) {
 
     #ifdef FUNCTION_ENTRY_DEBUG
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    int ret = SUCCESS;
+    //Cache the input params
+    request_idm->lock_id  = lock_id;
+    request_idm->mode_idm = mode;
+    request_idm->host_id  = host_id;
+    request_idm->drive    = drive;
+    request_idm->timeout  = timeout;
 
-    //TODO: change name to _nvme_idm_check_common_input() ??
-    ret = _nvme_idm_check_common_input(lock_id, mode, host_id, drive, lvb_size);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: input validation fail %d", __func__, ret);
-        #else
-        printf("%s: input validation fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
-
-    memset(request_idm, 0, sizeof(nvmeIdmRequest));
-    memset(cmd_nvme,    0, sizeof(nvmeIdmVendorCmd));
-    memset(data_idm,    0, sizeof(idmData));
+//TODO: This is variable for NVMe reads.  How handle?  MAY be variable for writes too (future).
+    request_idm->group_idm = IDM_GROUP_DEFAULT;   //Currently fixed for NVME writes
 
     switch(mode) {
         case IDM_MODE_EXCLUSIVE:
@@ -131,67 +105,12 @@ int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
         case IDM_MODE_SHAREABLE:
             request_idm->class_idm = IDM_CLASS_SHARED_PROTECTED_READ;
         default:
-//TODO: This case is the resultant default behavior of the equivalent scsi code.  Does this make sense???
-//          Talk to Tom about this.
-//          Feels like this should be an error
-            request_idm->class_idm = mode;
+            return -EINVAL;
+            //Below is the effective behavior of equivalent scsi code.  Seems wrong.
+            // request_idm->class_idm = mode;
     }
 
-    request_idm->lock_id  = lock_id;
-    request_idm->mode_idm = mode;
-    request_idm->host_id  = host_id;
-    request_idm->drive    = drive;
-
-    request_idm->cmd_nvme = cmd_nvme;
-    request_idm->data_idm = data_idm;
-    request_idm->data_len = sizeof(idmData);    // Constant for NVMe writes (only) to the IDM
-    request_idm->timeout  = timeout;
-
-//TODO: IDM API dependent variables: Leave here -OR- move up 1 level?
-    //kludge for inconsistent IDM API input params
-    if(lvb)
-        request_idm->lvb = lvb;
-    if(lvb_size)
-        request_idm->lvb_size  = lvb_size;
-
-    return ret;
-}
-
-//TODO: Still need to validate this this will work for synchronous reads too.
-/**
- * _nvme_idm_check_common_input - Validates the common IDM API input parameters.
- *
- * @lock_id:        Lock ID (64 bytes).
- * @mode:           Lock mode (unlock, shareable, exclusive).
- * @host_id:        Host ID (32 bytes).
- * @drive:          Drive path name.
- *
- * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
- */
-int _nvme_idm_check_common_input(char *lock_id, int mode, char *host_id,
-                                char *drive, int lvb_size) {
-
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
-
-    int ret = SUCCESS;
-
-    #ifndef COMPILE_STANDALONE
-    if (ilm_inject_fault_is_hit())
-        return -EIO;
-    #endif //COMPILE_STANDALONE
-
-    if (!lock_id || !host_id || !drive)
-        return -EINVAL;
-
-    if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
-        return -EINVAL;
-
-    if (lvb_size > IDM_LVB_SIZE_MAX)
-        return -EINVAL;
-
-    return ret;
+    return SUCCESS;
 }
 
 /**
@@ -291,47 +210,19 @@ int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme) {
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmVendorCmd *cmd_nvme = request_idm->cmd_nvme;
-    idmData *data_idm          = request_idm->data_idm;
+    nvmeIdmVendorCmd *cmd_nvme = &request_idm->cmd_nvme;
     int ret                    = SUCCESS;
 
     cmd_nvme->opcode_nvme        = opcode_nvme;
-    cmd_nvme->addr               = (uint64_t)(uintptr_t)data_idm;
-    cmd_nvme->data_len           = IDM_VENDOR_CMD_DATA_LEN_BYTES;  //Should be: sizeof(idmData) which should always be 512
-    cmd_nvme->ndt                = IDM_VENDOR_CMD_DATA_LEN_DWORDS;
+    cmd_nvme->addr               = (uint64_t)(uintptr_t)request_idm->data_idm;
+    cmd_nvme->data_len           = request_idm->data_len;
+    cmd_nvme->ndt                = request_idm->data_len / 4;
 //TODO: Change spec so don't have to do this 4-bit shift
     cmd_nvme->opcode_idm_bits7_4 = request_idm->opcode_idm << 4;
-    cmd_nvme->group_idm          = request_idm->group_idm;       //TODO: This isn't yet getting set anywhere for lock
+    cmd_nvme->group_idm          = request_idm->group_idm;
     cmd_nvme->timeout_ms         = VENDOR_CMD_TIMEOUT_DEFAULT;
 
     return ret;
-}
-
-/**
- * _nvme_idm_cmd_init_rd - Convenience function (during an NVMe read of the IDM) for initializing
- *                         the NVMe Vendor Specific Command command struct.
- *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- *
- * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
- */
-//TODO: Bring this back in when doing "read" side.
-// int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm) {
-//     return _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
-// }
-
-/**
- * _nvme_idm_cmd_init_wrt - Convenience function (during an NVMe write of the IDM) for initializing
- *                          the NVMe Vendor Specific Command command struct.
- *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- *
- * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
- */
-int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm) {
-    printf("%s: START\n", __func__);
-
-    return _nvme_idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
 }
 
 /**
@@ -363,7 +254,7 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
     }
 
     //TODO: Put this under a debug flag of some kind??
-    dumpNvmeCmdStruct(request_idm->cmd_nvme, 1, 1);
+    dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
     dumpIdmDataStruct(request_idm->data_idm);
 
     status_ioctl = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, request_idm->cmd_nvme);
@@ -378,7 +269,7 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
 
 //TODO: Keep this debug??
     printf("%s: status_ioctl=%d\n", __func__, status_ioctl);
-    printf("%s: ioctl cmd_nvme->result=%d\n", __func__, request_idm->cmd_nvme->result);
+    printf("%s: ioctl cmd_nvme->result=%d\n", __func__, request_idm->cmd_nvme.result);
 
 //TODO: Delete this eventually
 //Completion Queue Entry (CQE) SIDE-NOTE:
@@ -421,7 +312,7 @@ int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm) {
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmVendorCmd *cmd_nvme = request_idm->cmd_nvme;
+    nvmeIdmVendorCmd *cmd_nvme = &request_idm->cmd_nvme;
     idmData *data_idm          = request_idm->data_idm;
     int ret                    = SUCCESS;
 
@@ -429,18 +320,20 @@ int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm) {
     #ifndef COMPILE_STANDALONE
   	data_idm->time_now  = ilm_read_utc_time();
     #else
-  	data_idm->time_now  = 0;
+  	data_idm->time_now  = 1234567890;
     #endif //COMPILE_STANDALONE
 	data_idm->countdown = request_idm->timeout;
 	data_idm->class_idm = request_idm->class_idm;
 
 //TODO: ?? reverse bit order of next 3 destination arrays ??  (on scsi-side, using _scsi_data_swap())
-    memcpy(data_idm->host_id,      request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
-    memcpy(data_idm->resource_id,  request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
-    memcpy(data_idm->resource_ver, request_idm->lvb,     request_idm->lvb_size);  //TODO: On scsi-side, inconsistent use of lvb_size vs IDM_VALUE_LEN when copying lvb around
-                                                                                  //TODO: Aslo, minor inefficiency. Not always needed.  Copy anyway?  Conditional IF?
+    memcpy(data_idm->host_id,     request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
+    memcpy(data_idm->resource_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
+    if(request_idm->lvb)
+        memcpy(data_idm->resource_ver, request_idm->lvb, request_idm->lvb_size);
 
 	data_idm->resource_ver[0] = request_idm->res_ver_type;   //TODO: On scsi-side, why are "lvb" AND "res_ver_type" going into the same char array
+                                                                    // NOTE HERE: this line occurs on scsi-side AFTER a data order reversal (swap),
+                                                                    //            so it's not overwriting anything. How handle?
 
     return ret;
 }
@@ -477,16 +370,14 @@ int main(int argc, char *argv[])
             uint64_t    timeout     = 10;
 
             //Create required input structs the IDM API would normally create
-            nvmeIdmRequest   request_idm;
-            nvmeIdmVendorCmd cmd_nvme;
-            idmData          data_idm;
-            int              ret = SUCCESS;
+            nvmeIdmRequest *request_idm;
+            int            ret = SUCCESS;
 
             ret = nvme_idm_write_init(lock_id, mode, host_id,drive, timeout, 0, 0,
-                                      &request_idm, &cmd_nvme, &data_idm);
+                                      request_idm);
             printf("%s exiting with %d\n", argv[1], ret);
 
-            ret = nvme_idm_write(&request_idm);
+            ret = nvme_idm_write(request_idm);
             printf("%s exiting with %d\n", argv[1], ret);
         }
 

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -372,7 +372,7 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
         #else
         printf("%s: ioctl failed: %d\n", __func__, status_ioctl);
         #endif //COMPILE_STANDALONE
-        goto out;
+        return status_ioctl;
     }
 
 //TODO: Keep this debug??

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -16,7 +16,6 @@
 
 
 #define VENDOR_CMD_TIMEOUT_DEFAULT 15000     //TODO: Duplicated from SCSI. Uncertain behavior
-                                            //TODO: Separate timeout default for NVMe Vendor Cmds??
 
 //////////////////////////////////////////
 // Enums

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -127,11 +127,13 @@ typedef struct _nvmeIdmRequest {
 //////////////////////////////////////////
 
 int nvme_idm_write(nvmeIdmRequest *request_idm);
-int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
-                        idmData *data_idm, char *lock_id, int mode, char *host_id,
-                        char *drive, uint64_t timeout, char *lvb, int lvb_size);
+int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
+                        uint64_t timeout, char *lvb, int lvb_size,
+                        nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
+                        idmData *data_idm);
 
-int _nvme_idm_check_common_input(char *lock_id, int mode, char *host_id, char *drive, int lvb_size);
+int _nvme_idm_check_common_input(char *lock_id, int mode, char *host_id, char *drive,
+                                 int lvb_size);
 int _nvme_idm_cmd_check_status(int status, int opcode_idm);
 int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme);
 //int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm);

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -99,12 +99,12 @@ typedef struct _nvmeIdmVendorCmd {
 typedef struct _nvmeIdmRequest {
     //Cached "IDM API" input params
     char                *drive;
-	char                *lock_id;
-	char                *host_id;
+    char                *lock_id;
+    char                *host_id;
     int                 mode_idm;
-	//uint64_t            fd_async;
-	uint64_t            timeout;
-	char                *lvb;
+    //uint64_t            fd_async;
+    uint64_t            timeout;
+    char                *lvb;
     int                 lvb_size;   //TODO: should be unsigned, but public API setup with int.  size_t anyway?
 
     //IDM core structs

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -135,6 +135,7 @@ int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_idm,
 int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme);
 //int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm);
 int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm);
+int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm);
+int _nvme_idm_cmd_status_check(int status, int opcode_idm);
 int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm);
-int _nvme_send_cmd_idm(nvmeIdmRequest *request_idm);
-int _nvme_status_check(int status, int opcode_idm);
+int _nvme_idm_write_input_check(char *lock_id, int mode, char *host_id, char *drive);

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -7,6 +7,9 @@
  *                  to talk to the Linux kernel (via ioctl(), read() or write())
 */
 
+#ifndef __IDM_NVME_IO_H__
+#define __IDM_NVME_IO_H__
+
 #include <stdint.h>
 
 #include "idm_cmd_common.h"
@@ -14,9 +17,6 @@
 
 #define VENDOR_CMD_TIMEOUT_DEFAULT 15000     //TODO: Duplicated from SCSI. Uncertain behavior
                                             //TODO: Separate timeout default for NVMe Vendor Cmds??
-#define IDM_LOCK_ID_LEN_BYTES   64
-#define IDM_HOST_ID_LEN_BYTES   32
-
 
 //////////////////////////////////////////
 // Enums
@@ -95,7 +95,7 @@ typedef struct _nvmeIdmVendorCmd {
 // }eCqeStatusFields;
 
 
-//TODO: Using a bunch of pointer here.  SCSI was using COPIES of everything.  Any issues with this?? (string lengths??, kernel vs user space memory??)
+//TODO: Using a bunch of pointers here.  SCSI was using COPIES of everything.  Any issues with this?? (string lengths??, kernel vs user space memory??)
 //TODO: Add struct description HERE
 typedef struct _nvmeIdmRequest {
     //"IDM API" input params
@@ -116,7 +116,7 @@ typedef struct _nvmeIdmRequest {
     uint8_t             opcode_idm;
     uint8_t             group_idm;
     char                res_ver_type;  //TODO: How is this being used?  What does it represent in the NVMe CDW block?  What type should this be?
-    int                 data_len;       //TODO: Needed??  Seems like this can be determined in the lower-levels.
+    int                 data_len;
     uint64_t            class_idm;
 
 }nvmeIdmRequest;
@@ -138,4 +138,6 @@ int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm);
 int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm);
 int _nvme_idm_cmd_status_check(int status, int opcode_idm);
 int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm);
-int _nvme_idm_write_input_check(char *lock_id, int mode, char *host_id, char *drive);
+int _nvme_idm_write_input_check(char *lock_id, int mode, char *host_id, char *drive, int lvb_size);
+
+#endif /*__IDM_NVME_IO_H__ */

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -131,12 +131,12 @@ int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
                         idmData *data_idm, char *lock_id, int mode, char *host_id,
                         char *drive, uint64_t timeout, char *lvb, int lvb_size);
 
+int _nvme_idm_check_common_input(char *lock_id, int mode, char *host_id, char *drive, int lvb_size);
+int _nvme_idm_cmd_check_status(int status, int opcode_idm);
 int _nvme_idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme);
 //int _nvme_idm_cmd_init_rd(nvmeIdmRequest *request_idm);
 int _nvme_idm_cmd_init_wrt(nvmeIdmRequest *request_idm);
 int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm);
-int _nvme_idm_cmd_status_check(int status, int opcode_idm);
 int _nvme_idm_data_init_wrt(nvmeIdmRequest *request_idm);
-int _nvme_idm_write_input_check(char *lock_id, int mode, char *host_id, char *drive, int lvb_size);
 
 #endif /*__IDM_NVME_IO_H__ */

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -108,7 +108,7 @@ typedef struct _nvmeIdmRequest {
     int                 lvb_size;
 
     //IDM core structs
-    nvmeIdmVendorCmd    *cmd_idm;
+    nvmeIdmVendorCmd    *cmd_nvme;
     idmData             *data_idm;
 
     // Misc collection area for kludgy smuggling of parameters
@@ -127,7 +127,7 @@ typedef struct _nvmeIdmRequest {
 //////////////////////////////////////////
 
 int nvme_idm_write(nvmeIdmRequest *request_idm);
-int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_idm,
+int nvme_idm_write_init(nvmeIdmRequest *request_idm, nvmeIdmVendorCmd *cmd_nvme,
                         idmData *data_idm, char *lock_id, int mode, char *host_id,
                         char *drive, uint64_t timeout, char *lvb, int lvb_size);
 

--- a/src/idm_nvme_io_admin.h
+++ b/src/idm_nvme_io_admin.h
@@ -6,6 +6,9 @@
  * idm_nvme.h - NVMe interface for In-drive Mutex (IDM)
  */
 
+#ifndef __IDM_NVME_IO_ADMIN_H__
+#define __IDM_NVME_IO_ADMIN_H__
+
 #include <stdint.h>
 
 
@@ -181,5 +184,4 @@ int nvme_admin_identify(char *drive);
 void _gen_nvme_cmd_identify(struct nvme_admin_cmd *cmd_admin, nvmeIDCtrl *data_identify_ctrl);
 int _send_nvme_cmd_admin(char *drive, struct nvme_admin_cmd *cmd_admin);
 
-
-
+#endif /*__IDM_NVME_IO_ADMIN_H__ */

--- a/src/idm_nvme_io_admin.h
+++ b/src/idm_nvme_io_admin.h
@@ -13,7 +13,6 @@
 
 
 #define ADMIN_CMD_TIMEOUT_MS_DEFAULT 15000     //TODO: Duplicated from SCSI. Uncertain behavior
-                                            //TODO: Separate timeout default for NVMe Vendor Cmds??
 #define NVME_IDENTIFY_DATA_LEN_BYTES 4096
 
 //////////////////////////////////////////

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme_utils.c - Contains nvme-related helper utility functions.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "idm_nvme_utils.h"
+
+
+/**
+ * dumpIdmDataStruct - Convenience function for pretty printing the contends of the
+ *                     passed in data struct.
+ *                     Currently, outputs only to the CLI.
+ *
+ * @data_idm: Data structure for sending and receiving IDM-speicifc data.
+ *
+ * No return value
+ */
+void dumpIdmDataStruct(idmData *data_idm){
+
+    idmData *d = data_idm;
+
+    printf("IDM Data Struct: Fields\n");
+    printf("=======================\n");
+    printf("state\\ignored0        = 0x%0.16X (%u)\n", d->state,    d->state);
+    printf("modified\\time_now     = 0x%0.16X (%u)\n", d->modified, d->modified);
+    printf("countdown             = 0x%0.16X (%u)\n", d->countdown, d->countdown);
+    printf("class_idm             = 0x%0.16X (%u)\n", d->class_idm, d->class_idm);
+    printf("resource_ver          = '%s'\n", d->resource_ver);  //TODO: first char getting stomped on by "res_ver_type"
+    printf("resource_id (lock_id) = '%s'\n", d->resource_id);
+    printf("metadata              = '%s'\n", d->metadata);
+    printf("host_id               = '%s'\n", d->host_id);
+    printf("\n");
+}
+
+/**
+ * dumpNvmeCmdStruct - Convenience function for pretty printing the contends of the
+ *                     passed in data struct.
+ *                     Currently, outputs only to the CLI.
+ *
+ * @cmd_nvme:    NVMe Vendor Specific Command command word data structure.
+ * @view_fields: Boolean flag that outputs the struct's named fields.
+ * @view_cdws:   Boolean flag that outputs all the struct's data as 32-bit words.
+ *
+ * No return value
+ */
+void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields, int view_cdws) {
+
+    if(view_fields){
+        nvmeIdmVendorCmd *c = cmd_nvme;
+
+        printf("NVMe Command Struct: Fields\n");
+        printf("===========================\n");
+        printf("opcode_nvme       (CDW0[ 7:0])  = 0x%0.2X (%u)\n", c->opcode_nvme,  c->opcode_nvme);
+        printf("flags             (CDW0[15:8])  = 0x%0.2X (%u)\n", c->flags,        c->flags);
+        printf("command_id        (CDW0[32:16]) = 0x%0.4X (%u)\n", c->command_id,   c->command_id);
+        printf("nsid              (CDW1[32:0])  = 0x%0.8X (%u)\n", c->nsid,         c->nsid);
+        printf("cdw2              (CDW2[32:0])  = 0x%0.8X (%u)\n", c->cdw2,         c->cdw2);
+        printf("cdw3              (CDW3[32:0])  = 0x%0.8X (%u)\n", c->cdw3,         c->cdw3);
+        printf("metadata          (CDW4&5[64:0])= 0x%0.16X (%u)\n",c->metadata,     c->metadata);
+//TODO: There is a descrepency between views: specifically  "addr" and "cdw 6 & 7"
+        printf("addr              (CDW6&7[64:0])= 0x%0.16X (%u)\n",c->addr,         c->addr);
+        printf("metadata_len      (CDW8[32:0])  = 0x%0.8X (%u)\n", c->metadata_len, c->metadata_len);
+        printf("data_len          (CDW9[32:0])  = 0x%0.8X (%u)\n", c->data_len,     c->data_len);
+        printf("ndt               (CDW10[32:0]) = 0x%0.8X (%u)\n", c->ndt,          c->ndt);
+        printf("ndm               (CDW11[32:0]) = 0x%0.8X (%u)\n", c->ndm,          c->ndm);
+        printf("opcode_idm_bits7_4(CDW12[ 7:0]) = 0x%0.2X (%u)\n", c->opcode_idm_bits7_4, c->opcode_idm_bits7_4);
+        printf("group_idm         (CDW12[15:8]) = 0x%0.2X (%u)\n", c->group_idm,    c->group_idm);
+        printf("rsvd2             (CDW12[32:16])= 0x%0.4X (%u)\n", c->rsvd2,        c->rsvd2);
+        printf("cdw13             (CDW13[32:0]) = 0x%0.8X (%u)\n", c->cdw13,        c->cdw13);
+        printf("cdw14             (CDW14[32:0]) = 0x%0.8X (%u)\n", c->cdw14,        c->cdw14);
+        printf("cdw15             (CDW15[32:0]) = 0x%0.8X (%u)\n", c->cdw15,        c->cdw15);
+        printf("timeout_ms        (CDW16[32:0]) = 0x%0.8X (%u)\n", c->timeout_ms,   c->timeout_ms);
+        printf("result            (CDW17[32:0]) = 0x%0.8X (%u)\n", c->result,       c->result);
+        printf("\n");
+    }
+
+    if(view_cdws){
+        uint32_t *cdw = (uint32_t*)cmd_nvme;
+
+        printf("NVMe Command Struct: CDWs (hex)\n");
+        printf("===============================\n");
+        for(int i = 0; i <= 17; i++) {
+            printf("cdw%0.2d = 0x%0.8X\n", i, cdw[i]);
+        }
+        printf("\n");
+    }
+}

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -17,7 +17,7 @@
  *                     passed in data struct.
  *                     Currently, outputs only to the CLI.
  *
- * @data_idm: Data structure for sending and receiving IDM-speicifc data.
+ * @data_idm: Data structure for sending and receiving IDM-specifc data.
  *
  * No return value
  */
@@ -43,7 +43,7 @@ void dumpIdmDataStruct(idmData *data_idm){
  *                     passed in data struct.
  *                     Currently, outputs only to the CLI.
  *
- * @cmd_nvme:    NVMe Vendor Specific Command command word data structure.
+ * @cmd_nvme:       Data structure for NVMe Vendor Specific Commands.
  * @view_fields: Boolean flag that outputs the struct's named fields.
  * @view_cdws:   Boolean flag that outputs all the struct's data as 32-bit words.
  *

--- a/src/idm_nvme_utils.h
+++ b/src/idm_nvme_utils.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/*
+ * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ *
+ * idm_nvme_utils.h - Contains nvme-related helper utility functions.
+  */
+
+#ifndef __IDM_NVME_UTILS_H__
+#define __IDM_NVME_UTILS_H__
+
+#include "idm_cmd_common.h"
+#include "idm_nvme_io.h"
+
+
+void dumpIdmDataStruct(idmData *data_idm);
+void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields, int view_cdws);
+
+#endif /*__IDM_NVME_UTILS_H__ */


### PR DESCRIPTION
Add the remaining synchronous write idm api commands to the new NVMe interface.
Added:
`nvme_idm_break_lock()`
`nvme_idm_convert_lock()`
`nvme_idm_refresh_lock()`
`nvme_idm_renew_lock()`
`nvme_idm_unlock()`

Added a couple utility functions (in their own file) as well for easier debugging of the primary NVMe data structures.
Also, there was a fair amount of refactoring here (mostly renamings) as well, so the changes look worse than they really are.