### PR TITLE
FOSS-462: Refactor nvme function names.

### DIFF
--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -13,19 +13,20 @@
 
 #include "idm_nvme_io.h"
 
-
-int nvme_idm_break_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int nvme_idm_convert_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+//TODO: Refactor function params when scsi idm apis are renamed.
+//For reads, move "output" params to the end of the param list.
 int nvme_idm_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_lock_break(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_lock_convert(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int nvme_idm_lock_destroy(char *lock_id, int mode, char *host_id, char *drive);
+int nvme_idm_lock_refresh(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
+int nvme_idm_lock_renew(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int nvme_idm_read_host_state(char *lock_id, char *host_id, int *host_state, char *drive);
 int nvme_idm_read_lock_count(char *lock_id, char *host_id, int *count, int *self, char *drive);
 int nvme_idm_read_lock_mode(char *lock_id, int *mode, char *drive);
 int nvme_idm_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size, char *drive);
 int nvme_idm_read_mutex_group(char *drive, idmInfo **info_ptr, int *info_num);
 int nvme_idm_read_mutex_num(char *drive, unsigned int *num);
-int nvme_idm_refresh_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-int nvme_idm_renew_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
 int nvme_idm_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
 
 void _memory_free_idm_request(nvmeIdmRequest *request_idm);
@@ -34,22 +35,3 @@ int _validate_input_common(char *lock_id, char *host_id, char *drive);
 int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive);
 
 #endif /*__IDM_NVME_API_H__ */
-
-
-
-// int nvme_idm_lock(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-// int nvme_idm_lock_break(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-// int nvme_idm_lock_convert(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-// int nvme_idm_lock_destroy(char *lock_id, int mode, char *host_id, char *drive);
-// int nvme_idm_lock_refresh(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-// int nvme_idm_lock_renew(char *lock_id, int mode, char *host_id, char *drive, uint64_t timeout);
-// int nvme_idm_read_host_state(char *lock_id, char *host_id, int *host_state, char *drive);
-// int nvme_idm_read_lock_count(char *lock_id, char *host_id, int *count, int *self, char *drive);
-// int nvme_idm_read_lock_mode(char *lock_id, int *mode, char *drive);
-// int nvme_idm_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size, char *drive);
-// int nvme_idm_read_mutex_group(char *drive, struct idm_info **info_ptr, int *info_num);
-// int nvme_idm_read_mutex_num(char *drive, unsigned int *num);
-// int nvme_idm_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size, char *drive);
-
-
-

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -161,7 +161,7 @@ int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
         case IDM_MODE_SHAREABLE:
             request_idm->class = IDM_CLASS_SHARED_PROTECTED_READ;
         default:
-            //Other modes note support at this time
+            //Other modes not supported at this time
             return -EINVAL;
     }
 


### PR DESCRIPTION
Create a more consistent naming scheme.  WIll be utilized when the SCSI APIs are renamed as well.
Note that no functional changes were made to any of the functions.  They were just re-sorted in the .c file to reflect the new names.