### PR TITLE
Feature/foss 459 firmware debug fixes

### DIFF
--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -1068,9 +1068,9 @@ int main(int argc, char *argv[])
 
     //cli usage: idm_nvme_api lock
     if(argc >= 2){
-        char        lock_id[IDM_LOCK_ID_LEN_BYTES] = "lock_id";
+        char        lock_id[IDM_LOCK_ID_LEN_BYTES] = "0000000000000000000000000000000000000000000000000000000000000000";
         int         mode                           = IDM_MODE_EXCLUSIVE;
-        char        host_id[IDM_HOST_ID_LEN_BYTES] = "host_id_host_id";
+        char        host_id[IDM_HOST_ID_LEN_BYTES] = "00000000000000000000000000000000";
         uint64_t    timeout                        = 10;
         char        lvb[IDM_LVB_LEN_BYTES]         = "lvb";
         int         lvb_size                       = 5;

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -297,6 +297,7 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
     struct nvme_passthru_cmd *c = &cmd_nvme_passthru;
     int nvme_fd;
     int status_ioctl;
+    int nsid_ioctl;
     int ret = SUCCESS;
 
     //TODO: Put this under a debug flag of some kind??
@@ -316,10 +317,19 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
 
     memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
+//TODO: Need this?  CAN NOT be 0 though (get -1 err later when nvme cmd sent)
+    nsid_ioctl = ioctl(nvme_fd, NVME_IOCTL_ID);
+    if (nsid_ioctl <= 0)
+    {
+        printf("%s: nsid ioctl fail: %d\n", __func__, nsid_ioctl);
+        return nsid_ioctl;
+    }
+
     cmd_nvme_passthru.opcode       = request_idm->cmd_nvme.opcode_nvme;
     cmd_nvme_passthru.flags        = request_idm->cmd_nvme.flags;
     cmd_nvme_passthru.rsvd1        = request_idm->cmd_nvme.command_id;
-    cmd_nvme_passthru.nsid         = request_idm->cmd_nvme.nsid;
+    // cmd_nvme_passthru.nsid         = request_idm->cmd_nvme.nsid;
+    cmd_nvme_passthru.nsid         = nsid_ioctl;
     cmd_nvme_passthru.cdw2         = request_idm->cmd_nvme.cdw2;
     cmd_nvme_passthru.cdw3         = request_idm->cmd_nvme.cdw3;
     cmd_nvme_passthru.metadata     = request_idm->cmd_nvme.metadata;

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -293,9 +293,15 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
     printf("%s: START\n", __func__);
     #endif //FUNCTION_ENTRY_DEBUG
 
+    struct nvme_passthru_cmd cmd_nvme_passthru;
+    struct nvme_passthru_cmd *c = &cmd_nvme_passthru;
     int nvme_fd;
     int status_ioctl;
     int ret = SUCCESS;
+
+    //TODO: Put this under a debug flag of some kind??
+    dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
+    dumpIdmDataStruct(request_idm->data_idm);
 
     if ((nvme_fd = open(request_idm->drive, O_RDWR | O_NONBLOCK)) < 0) {
         #ifndef COMPILE_STANDALONE
@@ -308,22 +314,64 @@ int _nvme_idm_cmd_send(nvmeIdmRequest *request_idm) {
         return nvme_fd;
     }
 
-    //TODO: Put this under a debug flag of some kind??
-    dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
-    dumpIdmDataStruct(request_idm->data_idm);
+    memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
-    status_ioctl = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, request_idm->cmd_nvme);
+    cmd_nvme_passthru.opcode       = request_idm->cmd_nvme.opcode_nvme;
+    cmd_nvme_passthru.flags        = request_idm->cmd_nvme.flags;
+    cmd_nvme_passthru.rsvd1        = request_idm->cmd_nvme.command_id;
+    cmd_nvme_passthru.nsid         = request_idm->cmd_nvme.nsid;
+    cmd_nvme_passthru.cdw2         = request_idm->cmd_nvme.cdw2;
+    cmd_nvme_passthru.cdw3         = request_idm->cmd_nvme.cdw3;
+    cmd_nvme_passthru.metadata     = request_idm->cmd_nvme.metadata;
+    cmd_nvme_passthru.addr         = request_idm->cmd_nvme.addr;
+    cmd_nvme_passthru.metadata_len = request_idm->cmd_nvme.metadata_len;
+    cmd_nvme_passthru.data_len     = request_idm->cmd_nvme.data_len;
+    cmd_nvme_passthru.cdw10        = request_idm->cmd_nvme.ndt;
+    cmd_nvme_passthru.cdw11        = request_idm->cmd_nvme.ndm;
+    cmd_nvme_passthru.cdw12        = ((uint32_t)request_idm->cmd_nvme.rsvd2 << 16) |
+                                     ((uint32_t)request_idm->cmd_nvme.group_idm << 8) |
+                                     (uint32_t)request_idm->cmd_nvme.opcode_idm_bits7_4;
+    cmd_nvme_passthru.cdw13        = request_idm->cmd_nvme.cdw13;
+    cmd_nvme_passthru.cdw14        = request_idm->cmd_nvme.cdw14;
+    cmd_nvme_passthru.cdw15        = request_idm->cmd_nvme.cdw15;
+    cmd_nvme_passthru.timeout_ms   = request_idm->cmd_nvme.timeout_ms;
+
+    //TODO: Keep?  Refactor into debug func?
+    printf("nvme_passthru_cmd Struct: Fields\n");
+    printf("================================\n");
+    printf("opcode_nvme  (CDW0[ 7:0])  = 0x%0.2X (%u)\n", c->opcode,       c->opcode);
+    printf("flags        (CDW0[15:8])  = 0x%0.2X (%u)\n", c->flags,        c->flags);
+    printf("rsvd1        (CDW0[32:16]) = 0x%0.4X (%u)\n", c->rsvd1,        c->rsvd1);
+    printf("nsid         (CDW1[32:0])  = 0x%0.8X (%u)\n", c->nsid,         c->nsid);
+    printf("cdw2         (CDW2[32:0])  = 0x%0.8X (%u)\n", c->cdw2,         c->cdw2);
+    printf("cdw3         (CDW3[32:0])  = 0x%0.8X (%u)\n", c->cdw3,         c->cdw3);
+    printf("metadata     (CDW5&4[64:0])= 0x%0.16"PRIX64" (%u)\n",c->metadata, c->metadata);
+    printf("addr         (CDW7&6[64:0])= 0x%0.16"PRIX64" (%u)\n",c->addr, c->addr);
+    printf("metadata_len (CDW8[32:0])  = 0x%0.8X (%u)\n", c->metadata_len, c->metadata_len);
+    printf("data_len     (CDW9[32:0])  = 0x%0.8X (%u)\n", c->data_len,     c->data_len);
+    printf("cdw10        (CDW10[32:0]) = 0x%0.8X (%u)\n", c->cdw10,        c->cdw10);
+    printf("cdw11        (CDW11[32:0]) = 0x%0.8X (%u)\n", c->cdw11,        c->cdw11);
+    printf("cdw12        (CDW12[32:0]) = 0x%0.8X (%u)\n", c->cdw12,        c->cdw12);
+    printf("cdw13        (CDW13[32:0]) = 0x%0.8X (%u)\n", c->cdw13,        c->cdw13);
+    printf("cdw14        (CDW14[32:0]) = 0x%0.8X (%u)\n", c->cdw14,        c->cdw14);
+    printf("cdw15        (CDW15[32:0]) = 0x%0.8X (%u)\n", c->cdw15,        c->cdw15);
+    printf("timeout_ms   (CDW16[32:0]) = 0x%0.8X (%u)\n", c->timeout_ms,   c->timeout_ms);
+    printf("result       (CDW17[32:0]) = 0x%0.8X (%u)\n", c->result,       c->result);
+    printf("\n");
+
+    status_ioctl = ioctl(nvme_fd, NVME_IOCTL_IO_CMD, &cmd_nvme_passthru);
     if(status_ioctl) {
         #ifndef COMPILE_STANDALONE
         ilm_log_err("%s: ioctl failed: %d", __func__, status_ioctl);
         #else
         printf("%s: ioctl failed: %d\n", __func__, status_ioctl);
+        printf("%s: ioctl cmd_nvme_passthru.result=%d\n", __func__, cmd_nvme_passthru.result);
         #endif //COMPILE_STANDALONE
         return status_ioctl;
     }
 
     printf("%s: status_ioctl=%d\n", __func__, status_ioctl);
-    printf("%s: ioctl cmd_nvme->result=%d\n", __func__, request_idm->cmd_nvme.result);
+    printf("%s: ioctl cmd_nvme_passthru.result=%d\n", __func__, cmd_nvme_passthru.result);
 
 //TODO: Delete this eventually
 //Completion Queue Entry (CQE) SIDE-NOTE:

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -49,7 +49,7 @@ typedef enum _eNvmeIdmErrorCodes {
 //TODO: Add struct description HERE
 typedef struct _nvmeIdmVendorCmd {
     uint8_t             opcode_nvme;  //CDW0
-    uint8_t             flags;        //CDW0
+    uint8_t             flags;        //CDW0    psdt_bits7_6, rsvd0_bits5_2, fuse_bits1_0
     uint16_t            command_id;   //CDW0
     uint32_t            nsid;         //CDW1
     uint32_t            cdw2;         //CDW2


### PR DESCRIPTION
A couple bugs were found while debugging the new NVMe drive firmware. 
Two primary changes are:

1. transferring all NVMe CDW info to the built-in nvme struct type expected by ioctl(), and 
2. add a retrieval of the namespace id (nsid) for the nvme drive.  Can NOT leave as 0 (as ioctl() returns a -1).