### PR TITLE
FOSS-506: Allow NVMe devices names into drive_list

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -97,16 +97,16 @@ Loop Until Shutdown
       ilm_find_sg() ->> drive_thd_function(): SCSI generic node
       drive_thd_function() ->> ilm_read_device_wwn(): device path
       ilm_read_device_wwn() ->>  drive_thd_function(): WWN
-      drive_thd_function() ->> ilm_scsi_add_drive_path(): device path, SCSI generic node, WWN
+      drive_thd_function() ->> ilm_add_drive_path(): device path, SCSI generic node, WWN
     else action = remove
-      drive_thd_function() ->> ilm_scsi_del_drive_path(): device path
+      drive_thd_function() ->> ilm_del_drive_path(): device path
     else action = change
-      drive_thd_function() ->> ilm_scsi_del_drive_path(): device path
+      drive_thd_function() ->> ilm_del_drive_path(): device path
       drive_thd_function() ->> ilm_find_sg(): device name
       ilm_find_sg() ->> drive_thd_function(): SCSI generic node
       drive_thd_function() ->> ilm_read_device_wwn(): device path
       ilm_read_device_wwn() ->>  drive_thd_function(): WWN
-      drive_thd_function() ->> ilm_scsi_add_drive_path(): device path, SCSI generic node, WWN
+      drive_thd_function() ->> ilm_add_drive_path(): device path, SCSI generic node, WWN
     end
   end
 end

--- a/src/drive.h
+++ b/src/drive.h
@@ -22,10 +22,17 @@ char *ilm_scsi_get_first_sg(char *dev);
 char *ilm_scsi_convert_blk_name(char *blk_dev);
 int ilm_scsi_get_part_table_uuid(char *dev, uuid_t *id);
 int ilm_scsi_get_all_sgs(unsigned long wwn, char **sg_node, int sg_num);
-int ilm_scsi_list_init(void);
-void ilm_scsi_list_exit(void);
-int ilm_scsi_list_rescan(void);
+ int ilm_scsi_list_init(void);
+ void ilm_scsi_list_exit(void);
+// int ilm_scsi_list_rescan(void);
 int ilm_scsi_list_refresh(void);
 int ilm_scsi_drive_version(void);
 
+//NEW for NVMe
+int ilm_drive_list_init(void);//wraps/replaces: int ilm_scsi_list_init(void);
+int ilm_drive_list_exit(void);//wraps/replaces: int ilm_scsi_list_exit(void);
+int ilm_drive_list_rescan(void);//wraps/replaces: int ilm_scsi_list_rescan(void);
 #endif /* __DRIVE_H__ */
+
+//TODO: move static functions to top of .c file??
+//TODO: Add _ to start of static functions in .c file

--- a/src/main.c
+++ b/src/main.c
@@ -242,7 +242,8 @@ int main(int argc, char *argv[])
 	if (ret < 0)
 		goto signal_setup_fail;
 
-	ret = ilm_scsi_list_init();
+	// ret = ilm_scsi_list_init();
+	ret = ilm_drive_list_init();
 	if (ret < 0)
 		goto signal_setup_fail;
 


### PR DESCRIPTION
Fix the seagate_ilm service initialization to account for NVMe drive as well.