### PR TITLE
Feature/foss 477 update to coding std

### DIFF
--- a/src/idm_api.c
+++ b/src/idm_api.c
@@ -46,16 +46,16 @@ int idm_drive_version(int *version, char *drive)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_lock(char *lock_id, int mode, char *host_id, char *drive,
-		   uint64_t timeout)
+                   uint64_t timeout)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_lock(lock_id, mode, host_id, drive,
-					 timeout);
+		                         timeout);
 	else
 		ret = scsi_idm_sync_lock(lock_id, mode, host_id, drive,
-					 timeout);
+		                         timeout);
 
 	return ret;
 }
@@ -73,16 +73,16 @@ int idm_drive_lock(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_lock_async(char *lock_id, int mode, char *host_id, char *drive,
-			 uint64_t timeout, uint64_t *handle)
+                         uint64_t timeout, uint64_t *handle)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_lock(lock_id, mode, host_id, drive,
-					  timeout, handle);
+		                          timeout, handle);
 	else
 		ret = scsi_idm_async_lock(lock_id, mode, host_id, drive,
-					  timeout, handle);
+		                          timeout, handle);
 
 	return ret;
 }
@@ -100,16 +100,16 @@ int idm_drive_lock_async(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb,
-		     int lvb_size, char *drive)
+                     int lvb_size, char *drive)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_unlock(lock_id, mode, host_id, lvb,
-					   lvb_size, drive);
+		                           lvb_size, drive);
 	else
 		ret = scsi_idm_sync_unlock(lock_id, mode, host_id, lvb,
-					   lvb_size, drive);
+		                           lvb_size, drive);
 
 	return ret;
 }
@@ -128,16 +128,16 @@ int idm_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_unlock_async(char *lock_id, int mode, char *host_id, char *lvb,
-			   int lvb_size, char *drive, uint64_t *handle)
+                           int lvb_size, char *drive, uint64_t *handle)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_unlock(lock_id, mode, host_id, lvb,
-					    lvb_size, drive, handle);
+		                            lvb_size, drive, handle);
 	else
 		ret = scsi_idm_async_unlock(lock_id, mode, host_id, lvb,
-					    lvb_size, drive, handle);
+		                            lvb_size, drive, handle);
 
 	return ret;
 }
@@ -154,16 +154,16 @@ int idm_drive_unlock_async(char *lock_id, int mode, char *host_id, char *lvb,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive,
-			   uint64_t timeout)
+                           uint64_t timeout)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_lock_convert(lock_id, mode, host_id,
-						 drive, timeout);
+		                                 drive, timeout);
 	else
 		ret = scsi_idm_sync_lock_convert(lock_id, mode, host_id,
-						 drive, timeout);
+		                                 drive, timeout);
 
 	return ret;
 }
@@ -181,17 +181,17 @@ int idm_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_convert_lock_async(char *lock_id, int mode, char *host_id,
-				 char *drive, uint64_t timeout,
-				 uint64_t *handle)
+                                 char *drive, uint64_t timeout,
+                                 uint64_t *handle)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_lock_convert(lock_id, mode, host_id,
-						  drive, timeout, handle);
+		                                 drive, timeout, handle);
 	else
 		ret = scsi_idm_async_lock_convert(lock_id, mode, host_id,
-						  drive, timeout, handle);
+		                                  drive, timeout, handle);
 
 	return ret;
 }
@@ -208,16 +208,16 @@ int idm_drive_convert_lock_async(char *lock_id, int mode, char *host_id,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive,
-			 uint64_t timeout)
+                         uint64_t timeout)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_lock_renew(lock_id, mode, host_id, drive,
-					       timeout);
+		                               timeout);
 	else
 		ret = scsi_idm_sync_lock_renew(lock_id, mode, host_id, drive,
-					       timeout);
+		                               timeout);
 
 	return ret;
 }
@@ -236,16 +236,16 @@ int idm_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_renew_lock_async(char *lock_id, int mode, char *host_id,
-			       char *drive, uint64_t timeout, uint64_t *handle)
+                              char *drive, uint64_t timeout, uint64_t *handle)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_lock_renew(lock_id, mode, host_id, drive,
-						timeout, handle);
+		                                timeout, handle);
 	else
 		ret = scsi_idm_async_lock_renew(lock_id, mode, host_id, drive,
-						timeout, handle);
+		                                timeout, handle);
 
 	return ret;
 }
@@ -265,16 +265,16 @@ int idm_drive_renew_lock_async(char *lock_id, int mode, char *host_id,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_break_lock(char *lock_id, int mode, char *host_id,
-			 char *drive, uint64_t timeout)
+                         char *drive, uint64_t timeout)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_lock_break(lock_id, mode, host_id, drive,
-					       timeout);
+		                               timeout);
 	else
 		ret = scsi_idm_sync_lock_break(lock_id, mode, host_id, drive,
-					       timeout);
+		                               timeout);
 
 	return ret;
 }
@@ -292,16 +292,16 @@ int idm_drive_break_lock(char *lock_id, int mode, char *host_id,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_break_lock_async(char *lock_id, int mode, char *host_id,
-			       char *drive, uint64_t timeout, uint64_t *handle)
+                               char *drive, uint64_t timeout, uint64_t *handle)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_lock_break(lock_id, mode, host_id, drive,
-						timeout, handle);
+		                                timeout, handle);
 	else
 		ret = scsi_idm_async_lock_break(lock_id, mode, host_id, drive,
-						timeout, handle);
+		                                timeout, handle);
 
 	return ret;
 }
@@ -318,7 +318,7 @@ int idm_drive_break_lock_async(char *lock_id, int mode, char *host_id,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_write_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size,
-			char *drive)
+                        char *drive)
 {
 	/*
 	NOT IMPLEMENTED
@@ -353,7 +353,7 @@ int idm_drive_write_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_write_lvb_async(char *lock_id, char *host_id, char *lvb,
-			      int lvb_size, char *drive, uint64_t *handle)
+                              int lvb_size, char *drive, uint64_t *handle)
 {
 	/*
 	NOT IMPLEMENTED
@@ -387,16 +387,16 @@ int idm_drive_write_lvb_async(char *lock_id, char *host_id, char *lvb,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size,
-		       char *drive)
+                       char *drive)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_read_lvb(lock_id, host_id, lvb, lvb_size,
-					     drive);
+		                             drive);
 	else
 		ret = scsi_idm_sync_read_lvb(lock_id, host_id, lvb, lvb_size,
-					     drive);
+		                             drive);
 
 	return ret;
 }
@@ -412,7 +412,7 @@ int idm_drive_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_read_lvb_async(char *lock_id, char *host_id, char *drive,
-			     uint64_t *handle)
+                             uint64_t *handle)
 {
 	int ret;
 
@@ -437,16 +437,16 @@ int idm_drive_read_lvb_async(char *lock_id, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_read_lvb_async_result(char *drive, uint64_t handle, char *lvb,
-				    int lvb_size, int *result)
+                                    int lvb_size, int *result)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_get_result_lvb(handle, lvb, lvb_size,
-						    result);
+		                                    result);
 	else
 		ret = scsi_idm_async_get_result_lvb(handle, lvb, lvb_size,
-						    result);
+		                                    result);
 
 	return ret;
 }
@@ -463,16 +463,16 @@ int idm_drive_read_lvb_async_result(char *drive, uint64_t handle, char *lvb,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_lock_count(char *lock_id, char *host_id, int *count, int *self,
-			 char *drive)
+                         char *drive)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_read_lock_count(lock_id, host_id, count,
-						    self, drive);
+		                                    self, drive);
 	else
 		ret = scsi_idm_sync_read_lock_count(lock_id, host_id, count,
-						    self, drive);
+		                                    self, drive);
 
 	return ret;
 }
@@ -488,16 +488,16 @@ int idm_drive_lock_count(char *lock_id, char *host_id, int *count, int *self,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_lock_count_async(char *lock_id, char *host_id, char *drive,
-			       uint64_t *handle)
+                               uint64_t *handle)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_read_lock_count(lock_id, host_id, drive,
-						     handle);
+		                                     handle);
 	else
 		ret = scsi_idm_async_read_lock_count(lock_id, host_id, drive,
-						     handle);
+		                                     handle);
 
 	return ret;
 }
@@ -514,16 +514,16 @@ int idm_drive_lock_count_async(char *lock_id, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_lock_count_async_result(char *drive, uint64_t handle, int *count,
-				      int *self, int *result)
+                                      int *self, int *result)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_get_result_lock_count(handle, count,
-							   self, result);
+		                                           self, result);
 	else
 		ret = scsi_idm_async_get_result_lock_count(handle, count,
-							   self, result);
+		                                           self, result);
 
 	return ret;
 }
@@ -581,16 +581,16 @@ int idm_drive_lock_mode_async(char *lock_id, char *drive, uint64_t *handle)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_lock_mode_async_result(char *drive, uint64_t handle, int *mode,
-				     int *result)
+                                     int *result)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_async_get_result_lock_mode(handle, mode,
-							  result);
+		                                          result);
 	else
 		ret = scsi_idm_async_get_result_lock_mode(handle, mode,
-							  result);
+		                                          result);
 
 	return ret;
 }
@@ -643,16 +643,16 @@ void idm_drive_free_async_result(char *drive, uint64_t handle)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_host_state(char *lock_id, char *host_id, int *host_state,
-			 char *drive)
+                         char *drive)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_read_host_state(lock_id, host_id,
-						    host_state, drive);
+		                                    host_state, drive);
 	else
 		ret = scsi_idm_sync_read_host_state(lock_id, host_id,
-						    host_state, drive);
+		                                    host_state, drive);
 
 	return ret;
 }
@@ -687,10 +687,10 @@ int idm_drive_read_group(char *drive, struct idm_info **info_ptr, int *info_num)
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_read_mutex_group(drive, info_ptr,
-						     info_num);
+		                                     info_num);
 	else
 		ret = scsi_idm_sync_read_mutex_group(drive, info_ptr,
-						     info_num);
+		                                     info_num);
 
 	return ret;
 }
@@ -704,16 +704,16 @@ int idm_drive_read_group(char *drive, struct idm_info **info_ptr, int *info_num)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int idm_drive_destroy(char *lock_id, int mode, char *host_id,
-		      char *drive)
+                      char *drive)
 {
 	int ret;
 
 	if (strstr(drive, NVME_DEVICE_TAG))
 		ret = nvme_idm_sync_lock_destroy(lock_id, mode, host_id,
-						 drive);
+		                                 drive);
 	else
 		ret = nvme_idm_sync_lock_destroy(lock_id, mode, host_id,
-						 drive);
+		                                 drive);
 
 	return ret;
 }

--- a/src/idm_api.h
+++ b/src/idm_api.h
@@ -28,55 +28,55 @@ int idm_drive_destroy(char *lock_id, char *host_id, char *drive);
 
 int idm_drive_version(int *version, char *drive);
 int idm_drive_lock(char *lock_id, int mode, char *host_id, char *drive,
-		   uint64_t timeout);
+                   uint64_t timeout);
 int idm_drive_lock_async(char *lock_id, int mode, char *host_id, char *drive,
-			 uint64_t timeout, uint64_t *handle);
+                         uint64_t timeout, uint64_t *handle);
 int idm_drive_unlock(char *lock_id, int mode, char *host_id, char *lvb,
-		     int lvb_size, char *drive);
+                     int lvb_size, char *drive);
 int idm_drive_unlock_async(char *lock_id, int mode, char *host_id, char *lvb,
-			   int lvb_size, char *drive, uint64_t *handle);
+                           int lvb_size, char *drive, uint64_t *handle);
 int idm_drive_convert_lock(char *lock_id, int mode, char *host_id, char *drive,
-			   uint64_t timeout);
+                           uint64_t timeout);
 int idm_drive_convert_lock_async(char *lock_id, int mode, char *host_id,
-				 char *drive, uint64_t timeout,
-				 uint64_t *handle);
+                                 char *drive, uint64_t timeout,
+                                 uint64_t *handle);
 int idm_drive_renew_lock(char *lock_id, int mode, char *host_id, char *drive,
-			 uint64_t timeout);
+                         uint64_t timeout);
 int idm_drive_renew_lock_async(char *lock_id, int mode, char *host_id,
-			       char *drive, uint64_t timeout,
-			       uint64_t *handle);
+                               char *drive, uint64_t timeout,
+                               uint64_t *handle);
 int idm_drive_break_lock(char *lock_id, int mode, char *host_id, char *drive,
-			 uint64_t timeout);
+                         uint64_t timeout);
 int idm_drive_break_lock_async(char *lock_id, int mode, char *host_id,
-			       char *drive, uint64_t timeout,
-			       uint64_t *handle);
+                               char *drive, uint64_t timeout,
+                               uint64_t *handle);
 int idm_drive_write_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size,
-			char *drive);
+                        char *drive);
 int idm_drive_write_lvb_async(char *lock_id, char *host_id, char *lvb,
-			      int lvb_size, char *drive, uint64_t *handle);
+                              int lvb_size, char *drive, uint64_t *handle);
 
 int idm_drive_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size,
-		       char *drive);
+                       char *drive);
 int idm_drive_read_lvb_async(char *lock_id, char *host_id, char *drive,
-			     uint64_t *handle);
+                             uint64_t *handle);
 int idm_drive_read_lvb_async_result(char *drive, uint64_t handle, char *lvb,
-				    int lvb_size, int *result);
+                                    int lvb_size, int *result);
 int idm_drive_lock_count(char *lock_id, char *host_id, int *count, int *self,
-			 char *drive);
+                         char *drive);
 int idm_drive_lock_count_async(char *lock_id, char *host_id, char *drive,
-			       uint64_t *handle);
+                               uint64_t *handle);
 int idm_drive_lock_count_async_result(char *drive, uint64_t handle, int *count,
-				      int *self, int *result);
+                                      int *self, int *result);
 int idm_drive_lock_mode(char *lock_id, int *mode, char *drive);
 int idm_drive_lock_mode_async(char *lock_id, char *drive, uint64_t *handle);
 int idm_drive_lock_mode_async_result(char *drive, uint64_t handle, int *mode,
-				     int *result);
+                                     int *result);
 int idm_drive_read_group(char *drive, struct idm_info **info_ptr,
-			 int *info_num);
+                         int *info_num);
 int idm_drive_destroy(char *lock_id, int mode, char *host_id, char *drive);
 int idm_drive_async_result(char *drive, uint64_t handle, int *result);
 int idm_drive_host_state(char *lock_id, char *host_id, int *host_state,
-			 char *drive);
+                         char *drive);
 
 int idm_drive_whitelist(char *drive, char **whitelist, int *whitelist_num);
 

--- a/src/idm_cmd_common.c
+++ b/src/idm_cmd_common.c
@@ -24,8 +24,8 @@
  */
 void bswap_char_arr(char *dest, char *src, int len)
 {
-    int i;
-    for (i = 0; i < len; i++) {
-        dest[i] = src[len - i - 1];
-    }
+	int i;
+	for (i = 0; i < len; i++) {
+		dest[i] = src[len - i - 1];
+	}
 }

--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -27,7 +27,7 @@
 #define IDM_HOST_ID_LEN_BYTES       32
 #define IDM_LVB_LEN_BYTES            8
 
-// Other idmData char array lengths
+// Other struct idm_data char array lengths
 #define IDM_DATA_RESOURCE_VER_LEN_BYTES 8
 #define IDM_DATA_RESERVED_0_LEN_BYTES   24
 #define IDM_DATA_METADATA_LEN_BYTES     64
@@ -43,75 +43,75 @@
 //////////////////////////////////////////
 // Enums
 //////////////////////////////////////////
-typedef enum _eIdmClasses {
-    IDM_CLASS_EXCLUSIVE             = 0,
-    IDM_CLASS_PROTECTED_WRITE       = 0x1,
-    IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
-}eIdmClasses;
+enum idm_classes {
+	IDM_CLASS_EXCLUSIVE             = 0,
+	IDM_CLASS_PROTECTED_WRITE       = 0x1,
+	IDM_CLASS_SHARED_PROTECTED_READ = 0x2,
+};
 
-typedef enum _eIdmGroups {
-    IDM_GROUP_DEFAULT = 1,
-    IDM_GROUP_INQUIRY = 0xFF,
-}eIdmGroups;
+enum idm_groups {
+	IDM_GROUP_DEFAULT = 1,
+	IDM_GROUP_INQUIRY = 0xFF,
+};
 
-typedef enum _eIdmModes {
-    IDM_MODE_UNLOCK    = 0,
-    IDM_MODE_EXCLUSIVE = 0x1,
-    IDM_MODE_SHAREABLE = 0x2,
-}eIdmModes;
+enum idm_modes {
+	IDM_MODE_UNLOCK    = 0,
+	IDM_MODE_EXCLUSIVE = 0x1,
+	IDM_MODE_SHAREABLE = 0x2,
+};
 
-typedef enum _eIdmOpcodes {
-    IDM_OPCODE_NORMAL   = 0x0,
-    IDM_OPCODE_INIT     = 0x1,
-    IDM_OPCODE_TRYLOCK  = 0x2,
-    IDM_OPCODE_LOCK     = 0x3,
-    IDM_OPCODE_UNLOCK   = 0x4,
-    IDM_OPCODE_REFRESH  = 0x5,
-    IDM_OPCODE_BREAK    = 0x6,
-    IDM_OPCODE_DESTROY  = 0x7,
-}eIdmOpcodes;  //NVMe CDW12 mutex opcode
+enum idm_opcodes {
+	IDM_OPCODE_NORMAL   = 0x0,
+	IDM_OPCODE_INIT     = 0x1,
+	IDM_OPCODE_TRYLOCK  = 0x2,
+	IDM_OPCODE_LOCK     = 0x3,
+	IDM_OPCODE_UNLOCK   = 0x4,
+	IDM_OPCODE_REFRESH  = 0x5,
+	IDM_OPCODE_BREAK    = 0x6,
+	IDM_OPCODE_DESTROY  = 0x7,
+};  //NVMe CDW12 mutex opcode
 
-typedef enum _eIdmResVer {
-    IDM_RES_VER_NO_UPDATE_NO_VALID = 0,
-    IDM_RES_VER_UPDATE_NO_VALID    = 0x1,
-    IDM_RES_VER_UPDATE_VALID       = 0x2,
-    IDM_RES_VER_INVALID            = 0x3,
-}eIdmResVer;
+enum idm_resource_version {
+	IDM_RES_VER_NO_UPDATE_NO_VALID = 0,
+	IDM_RES_VER_UPDATE_NO_VALID    = 0x1,
+	IDM_RES_VER_UPDATE_VALID       = 0x2,
+	IDM_RES_VER_INVALID            = 0x3,
+};
 
-typedef enum _eIdmStates {
-    IDM_STATE_UNINIT            = 0,
-    IDM_STATE_LOCKED            = 0x101,
-    IDM_STATE_UNLOCKED          = 0x102,
-    IDM_STATE_MULTIPLE_LOCKED   = 0x103,
-    IDM_STATE_TIMEOUT           = 0x104,
-    IDM_STATE_DEAD              = 0xdead,
-}eIdmStates;
+enum idm_states {
+	IDM_STATE_UNINIT            = 0,
+	IDM_STATE_LOCKED            = 0x101,
+	IDM_STATE_UNLOCKED          = 0x102,
+	IDM_STATE_MULTIPLE_LOCKED   = 0x103,
+	IDM_STATE_TIMEOUT           = 0x104,
+	IDM_STATE_DEAD              = 0xdead,
+};
 
 //////////////////////////////////////////
 // Structs
 //////////////////////////////////////////
-typedef struct _idmData {
-    union {
-        uint64_t    state;      // For idm_read //NOTE:uint32_t in firmware, upper 32bit ignored
-        uint64_t    ignored0;   // For idm_write
-    };
-    union {
-        uint64_t    modified;    // For idm_read
-        uint64_t    time_now;    // For idm_write
-    };
-    uint64_t    countdown;
-    uint64_t    class;
-    char        resource_ver[IDM_DATA_RESOURCE_VER_LEN_BYTES];
-    char        rsvd0[IDM_DATA_RESERVED_0_LEN_BYTES];
-    char        resource_id[IDM_LOCK_ID_LEN_BYTES]; // resource_id == lock_id
-    char        metadata[IDM_DATA_METADATA_LEN_BYTES];
-    char        host_id[IDM_HOST_ID_LEN_BYTES];
-    char        rsvd1[IDM_DATA_RESERVED_1_LEN_BYTES];
-    union {
-        char    rsvd2[256];      // For idm_read
-        char    ignored1[256];   // For idm_write
-    };
-}idmData;
+struct idm_data {
+	union {
+		uint64_t    state;      // For idm_read //NOTE:uint32_t in firmware, upper 32bit ignored
+		uint64_t    ignored0;   // For idm_write
+	};
+	union {
+		uint64_t    modified;    // For idm_read
+		uint64_t    time_now;    // For idm_write
+	};
+	uint64_t    countdown;
+	uint64_t    class;
+	char        resource_ver[IDM_DATA_RESOURCE_VER_LEN_BYTES];
+	char        rsvd0[IDM_DATA_RESERVED_0_LEN_BYTES];
+	char        resource_id[IDM_LOCK_ID_LEN_BYTES]; // resource_id == lock_id
+	char        metadata[IDM_DATA_METADATA_LEN_BYTES];
+	char        host_id[IDM_HOST_ID_LEN_BYTES];
+	char        rsvd1[IDM_DATA_RESERVED_1_LEN_BYTES];
+	union {
+		char    rsvd2[256];      // For idm_read
+		char    ignored1[256];   // For idm_write
+	};
+};
 
 struct idm_info {
 	/* Lock ID */

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -48,7 +48,7 @@
  */
 void nvme_idm_async_free_result(uint64_t handle)
 {
-	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)request_idm;
+	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 
 	_memory_free_idm_request(request_idm);
 }
@@ -68,7 +68,7 @@ int nvme_idm_async_get_result(uint64_t handle, int *result)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int            ret          = SUCCESS;
 
 	ret = nvme_idm_async_data_rcv(request_idm, result);
@@ -123,7 +123,7 @@ int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int            ret          = SUCCESS;
 
 	// Initialize the return parameters
@@ -193,7 +193,7 @@ int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int            ret          = SUCCESS;
 
 	// Initialize the return parameter
@@ -261,7 +261,7 @@ int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int            ret          = SUCCESS;
 
 	//TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
@@ -329,7 +329,7 @@ int nvme_idm_async_lock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int ret = SUCCESS;  //TODO: Should ALL of these be initialized to FAILURE, instead of SUCCESS???  Probably going to be case-by-case
 
 	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
@@ -382,7 +382,7 @@ int nvme_idm_async_lock_break(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int ret = SUCCESS;
 
 	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
@@ -454,7 +454,7 @@ int nvme_idm_async_lock_destroy(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int ret = SUCCESS;
 
 	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
@@ -506,7 +506,7 @@ int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int ret = SUCCESS;
 
 	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
@@ -579,7 +579,7 @@ int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_read_lock_count(ASYNC_ON, lock_id, host_id, drive,
@@ -628,7 +628,7 @@ int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_read_lock_mode(ASYNC_ON, lock_id, drive, &request_idm);
@@ -678,7 +678,7 @@ int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_read_lvb(ASYNC_ON, lock_id, host_id, drive, &request_idm);
@@ -730,7 +730,7 @@ int nvme_idm_async_unlock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
@@ -771,7 +771,7 @@ EXIT:
  */
 int nvme_idm_get_fd(uint64_t handle)
 {
-	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 
 	return request_idm->fd_nvme;
 }
@@ -811,7 +811,7 @@ int nvme_idm_sync_lock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int ret = SUCCESS;
 
 	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
@@ -859,7 +859,7 @@ int nvme_idm_sync_lock_break(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
@@ -923,7 +923,7 @@ int nvme_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int ret = SUCCESS;
 
 	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
@@ -969,7 +969,7 @@ int nvme_idm_sync_lock_refresh(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
@@ -1034,7 +1034,7 @@ int nvme_idm_sync_read_host_state(char *lock_id, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1106,7 +1106,7 @@ int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1178,7 +1178,7 @@ int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1250,7 +1250,7 @@ int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	//TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
@@ -1320,7 +1320,7 @@ int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1388,7 +1388,7 @@ int nvme_idm_sync_read_mutex_num(char *drive, unsigned int *mutex_num)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 //TODO: The SCSI-side code tends to set this to 0 on certain failures.
@@ -1450,7 +1450,7 @@ int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmRequest *request_idm;
+	struct idm_nvme_request *request_idm;
 	int            ret = SUCCESS;
 
 	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
@@ -1493,7 +1493,7 @@ EXIT:
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
-               uint64_t timeout, nvmeIdmRequest **request_idm)
+               uint64_t timeout, struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1557,7 +1557,7 @@ int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
-                     uint64_t timeout, nvmeIdmRequest **request_idm)
+                     uint64_t timeout, struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1620,7 +1620,7 @@ int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
-                       nvmeIdmRequest **request_idm)
+                       struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1684,7 +1684,7 @@ int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
-                       uint64_t timeout, nvmeIdmRequest **request_idm)
+                       uint64_t timeout, struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1746,7 +1746,7 @@ int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_host_state(char *lock_id, char *host_id, char *drive,
-                          nvmeIdmRequest **request_idm)
+                          struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1794,7 +1794,7 @@ int _init_read_host_state(char *lock_id, char *host_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
-                          char *drive, nvmeIdmRequest **request_idm)
+                          char *drive, struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1862,7 +1862,7 @@ int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
-                         nvmeIdmRequest **request_idm)
+                         struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1932,7 +1932,7 @@ int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
-                   nvmeIdmRequest **request_idm)
+                   struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -1994,7 +1994,7 @@ int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _init_read_mutex_group(char *drive, nvmeIdmRequest **request_idm)
+int _init_read_mutex_group(char *drive, struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -2039,7 +2039,7 @@ int _init_read_mutex_group(char *drive, nvmeIdmRequest **request_idm)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _init_read_mutex_num(char *drive, nvmeIdmRequest **request_idm)
+int _init_read_mutex_num(char *drive, struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -2087,7 +2087,8 @@ int _init_read_mutex_num(char *drive, nvmeIdmRequest **request_idm)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
-                 int lvb_size, char *drive, nvmeIdmRequest **request_idm)
+                 int lvb_size, char *drive,
+		 struct idm_nvme_request **request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -2152,7 +2153,7 @@ int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-void _memory_free_idm_request(nvmeIdmRequest *request_idm) {
+void _memory_free_idm_request(struct idm_nvme_request *request_idm) {
 
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -2181,7 +2182,7 @@ void _memory_free_idm_request(nvmeIdmRequest *request_idm) {
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _memory_init_idm_request(nvmeIdmRequest **request_idm,
+int _memory_init_idm_request(struct idm_nvme_request **request_idm,
                              unsigned int data_num)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
@@ -2191,7 +2192,7 @@ int _memory_init_idm_request(nvmeIdmRequest **request_idm,
 	int data_len;
 	int ret = SUCCESS;
 
-	*request_idm = malloc(sizeof(nvmeIdmRequest));
+	*request_idm = malloc(sizeof(struct idm_nvme_request));
 	if (!request_idm) {
 		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: request memory allocate fail", __func__);
@@ -2202,7 +2203,7 @@ int _memory_init_idm_request(nvmeIdmRequest **request_idm,
 	}
 	memset((*request_idm), 0, sizeof(**request_idm));
 
-	data_len                 = sizeof(idmData) * data_num;
+	data_len                 = sizeof(struct idm_data) * data_num;
 	(*request_idm)->data_idm = malloc(data_len);
 	if (!(*request_idm)->data_idm) {
 		_memory_free_idm_request((*request_idm));
@@ -2233,13 +2234,13 @@ int _memory_init_idm_request(nvmeIdmRequest **request_idm,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state)
+int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	idmData        *data_idm;
+	struct idm_data        *data_idm;
 	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
 	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
 	int            i;
@@ -2300,13 +2301,14 @@ int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_lock_count(nvmeIdmRequest *request_idm, int *count, int *self)
+int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
+                      int *self)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	idmData        *data_idm;
+	struct idm_data        *data_idm;
 	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
 	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
 	int            i;
@@ -2389,13 +2391,13 @@ EXIT:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode)
+int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	idmData        *data_idm;
+	struct idm_data        *data_idm;
 	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
 	int            i;
 	unsigned int   mutex_num = request_idm->data_num;
@@ -2477,13 +2479,13 @@ int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size)
+int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	idmData        *data_idm;
+	struct idm_data        *data_idm;
 	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
 	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
 	int            i;
@@ -2528,14 +2530,14 @@ int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_mutex_group(nvmeIdmRequest *request_idm, struct idm_info **info_ptr,
-                       int *info_num)
+int _parse_mutex_group(struct idm_nvme_request *request_idm,
+                       struct idm_info **info_ptr, int *info_num)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	idmData        *data_idm;
+	struct idm_data        *data_idm;
 	unsigned int   mutex_num = request_idm->data_num;
 	int            i, ret    = SUCCESS;
 	uint64_t       state, class;
@@ -2613,7 +2615,8 @@ EXIT:
  *                  requested IDM action.
  * @mutex_num:      Returned number of mutexes present on the drive.
  */
-void _parse_mutex_num(nvmeIdmRequest *request_idm, unsigned int *mutex_num)
+void _parse_mutex_num(struct idm_nvme_request *request_idm,
+                      unsigned int *mutex_num)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2240,12 +2240,12 @@ int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_data        *data_idm;
-	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
-	int            i;
-	unsigned int   mutex_num = request_idm->data_num;
-	int            ret       = SUCCESS;
+	struct idm_data    *data_idm;
+	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	char               bswap_host_id[IDM_HOST_ID_LEN_BYTES];
+	int                i;
+	unsigned int       mutex_num = request_idm->data_num;
+	int                ret       = SUCCESS;
 
 	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
 	               IDM_LOCK_ID_LEN_BYTES);
@@ -2308,13 +2308,13 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_data        *data_idm;
-	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
-	int            i;
-	unsigned int   mutex_num = request_idm->data_num;
-	int            ret = SUCCESS;
-	uint64_t       state, locked;
+	struct idm_data    *data_idm;
+	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	char               bswap_host_id[IDM_HOST_ID_LEN_BYTES];
+	int                i;
+	unsigned int       mutex_num = request_idm->data_num;
+	int                ret = SUCCESS;
+	uint64_t           state, locked;
 
 	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
 	               IDM_LOCK_ID_LEN_BYTES);
@@ -2397,12 +2397,12 @@ int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_data        *data_idm;
-	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-	int            i;
-	unsigned int   mutex_num = request_idm->data_num;
-	int            ret       = SUCCESS;
-	uint64_t       state, class;
+	struct idm_data    *data_idm;
+	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	int                i;
+	unsigned int       mutex_num = request_idm->data_num;
+	int                ret       = SUCCESS;
+	uint64_t           state, class;
 
 	bswap_char_arr(bswap_lock_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
 
@@ -2485,12 +2485,12 @@ int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_data        *data_idm;
-	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
-	int            i;
-	unsigned int   mutex_num = request_idm->data_num;
-	int            ret       = SUCCESS;
+	struct idm_data    *data_idm;
+	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	char               bswap_host_id[IDM_HOST_ID_LEN_BYTES];
+	int                i;
+	unsigned int       mutex_num = request_idm->data_num;
+	int                ret       = SUCCESS;
 
 	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
 	               IDM_LOCK_ID_LEN_BYTES);
@@ -2537,11 +2537,11 @@ int _parse_mutex_group(struct idm_nvme_request *request_idm,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_data        *data_idm;
-	unsigned int   mutex_num = request_idm->data_num;
-	int            i, ret    = SUCCESS;
-	uint64_t       state, class;
-	struct idm_info        *info_list, *info;
+	struct idm_data    *data_idm;
+	unsigned int       mutex_num = request_idm->data_num;
+	int                i, ret    = SUCCESS;
+	uint64_t           state, class;
+	struct idm_info    *info_list, *info;
 
 	info_list = malloc(sizeof(struct idm_info) * mutex_num);
 	if (!info_list) {
@@ -2740,7 +2740,7 @@ int main(int argc, char *argv[])
         int             result=0;
         unsigned int    mutex_num;
         unsigned int    info_num;
-        struct idm_info         *info_list;
+        struct idm_info *info_list;
         int             host_state;
         int             count;
         int             self;

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -48,246 +48,270 @@
  */
 void nvme_idm_async_free_result(uint64_t handle)
 {
-    nvmeIdmRequest *request_idm = (nvmeIdmRequest *)request_idm;
+	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)request_idm;
 
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 }
 
 /**
  * nvme_idm_async_get_result - Retreive the result for normal async operations.
  *
  * @handle:      NVMe request handle for the previously sent NVMe cmd.
- * @result:      Returned result (0 or -ve value) for the previously sent NVMe command.
+ * @result:      Returned result (0 or -ve value) for the previously sent NVMe
+ *               command.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_get_result(uint64_t handle, int *result) {
+int nvme_idm_async_get_result(uint64_t handle, int *result)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	int            ret          = SUCCESS;
 
-    nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
-    int            ret          = SUCCESS;
+	ret = nvme_idm_async_data_rcv(request_idm, result);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_data_rcv fail %d\n",
+		       __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    ret = nvme_idm_async_data_rcv(request_idm, result);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_data_rcv fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
-
-//TODO: How should I handle the error code from the current VS the previous command??
-//          Especially as compared to what the SCSI code does.
-//          Talk to Tom.
-    if (*result < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: previous async cmd fail result=%d", __func__, *result);
-        #else
-        printf("%s: previous async cmd fail: result=%d\n", __func__, *result);
-        #endif //COMPILE_STANDALONE
-    }
+	//TODO: How should I handle the error code from the current VS the
+	//      previous command??
+	//          Especially as compared to what the SCSI code does.
+	//          Talk to Tom.
+	if (*result < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: previous async cmd fail result=%d",
+		            __func__, *result);
+		#else
+		printf("%s: previous async cmd fail: result=%d\n",
+		       __func__, *result);
+		#endif //COMPILE_STANDALONE
+	}
 
 EXIT:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_async_get_result_lock_count - Asynchronously retreive the result for a previous
- * asynchronous read lock count request.
+ * nvme_idm_async_get_result_lock_count - Asynchronously retreive the result
+ * for a previous asynchronous read lock count request.
  *
  * @handle:     NVMe request handle for the previously sent NVMe cmd.
  * @count:      Returned lock count.
  *              Referenced value set to 0 on error.
  * @self:       Returned self count.
  *              Referenced value set to 0 on error.
- * @result:     Returned result (0 or -ve value) for the previously sent NVMe command.
+ * @result:     Returned result (0 or -ve value) for the previously sent
+ *              NVMe command.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count, int *self, int *result) {
+int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count,
+                                         int *self, int *result)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	int            ret          = SUCCESS;
 
-    nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
-    int            ret          = SUCCESS;
+	// Initialize the return parameters
+	*count = 0;
+	*self  = 0;
 
-    // Initialize the return parameters
-    *count = 0;
-    *self  = 0;
+	ret = nvme_idm_async_data_rcv(request_idm, result);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_data_rcv(request_idm, result);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_data_rcv fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	if (*result < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: previous async cmd fail: result=%d",
+		            __func__, *result);
+		#else
+		printf("%s: previous async cmd fail: result=%d\n",
+		       __func__, *result);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    if (*result < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: previous async cmd fail: result=%d", __func__, *result);
-        #else
-        printf("%s: previous async cmd fail: result=%d\n", __func__, *result);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_lock_count(request_idm, count, self);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_lock_count fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_lock_count fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_lock_count(request_idm, count, self);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_lock_count fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_lock_count fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: lock_count=%d, self_count=%d", __func__, *count, *self);
-    #else
-    printf("%s: found: lock_count=%d, self_count=%d\n", __func__, *count, *self);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: lock_count=%d, self_count=%d",
+	            __func__, *count, *self);
+	#else
+	printf("%s: found: lock_count=%d, self_count=%d\n",
+	       __func__, *count, *self);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_async_get_result_lock_mode - Asynchronously retreive the result for a previous
- * asynchronous read lock mode request.
+ * nvme_idm_async_get_result_lock_mode - Asynchronously retreive the result
+ * for a previous asynchronous read lock mode request.
  *
  * @handle:     NVMe request handle for the previously sent NVMe cmd.
  * @mode:       Returned lock mode (unlock, shareable, exclusive).
  *              Referenced value set to -1 on error.
- * @result:     Returned result (0 or -ve value) for the previously sent NVMe command.
+ * @result:     Returned result (0 or -ve value) for the previously sent
+ *              NVMe command.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode, int *result) {
+int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode,
+                                        int *result)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	int            ret          = SUCCESS;
 
-    nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
-    int            ret          = SUCCESS;
+	// Initialize the return parameter
+	*mode = -1;    //TODO: hardcoded state. add an "error" state to the enum?
 
-    // Initialize the return parameter
-    *mode = -1;    //TODO: hardcoded state. add an "error" state to the enum?
+	ret = nvme_idm_async_data_rcv(request_idm, result);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_data_rcv(request_idm, result);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_data_rcv fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	if (*result < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: previous async cmd fail: result=%d",
+		            __func__, *result);
+		#else
+		printf("%s: previous async cmd fail: result=%d\n",
+		       __func__, *result);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    if (*result < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: previous async cmd fail: result=%d", __func__, *result);
-        #else
-        printf("%s: previous async cmd fail: result=%d\n", __func__, *result);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_lock_mode(request_idm, mode);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_lock_mode fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_lock_mode fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_lock_mode(request_idm, mode);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_lock_mode fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_lock_mode fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: mode=%d", __func__, *mode);
-    #else
-    printf("%s: found: mode=%d\n", __func__, *mode);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: mode=%d", __func__, *mode);
+	#else
+	printf("%s: found: mode=%d\n", __func__, *mode);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_async_get_result_lvb - Asynchronously retreive the result for a previous
- * asynchronous read lvb request.
+ * nvme_idm_async_get_result_lvb - Asynchronously retreive the result for a
+ * previous asynchronous read lvb request.
  *
  * @handle:     NVMe request handle for the previously sent NVMe cmd.
  * @mode:       Returned lock mode (unlock, shareable, exclusive).
  *              Referenced value set to -1 on error.
  * @lvb_size:   Lock value block size.
- * @result:     Returned result (0 or -ve value) for the previously sent NVMe command.
+ * @result:     Returned result (0 or -ve value) for the previously sent
+ *              NVMe command.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size, int *result) {
+int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size,
+                                  int *result)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	int            ret          = SUCCESS;
 
-    nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
-    int            ret          = SUCCESS;
+	//TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
+	//However, this requires an IDM API parameter type change.
+	if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_LEN_BYTES))
+		return -EINVAL;
 
-    //TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
-    //However, this requires an IDM API parameter type change.
-    if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_LEN_BYTES))
-        return -EINVAL;
+	ret = nvme_idm_async_data_rcv(request_idm, result);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_data_rcv(request_idm, result);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_data_rcv fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	if (*result < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: previous async cmd fail: result=%d",
+		            __func__, *result);
+		#else
+		printf("%s: previous async cmd fail: result=%d\n",
+		       __func__, *result);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    if (*result < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: previous async cmd fail: result=%d", __func__, *result);
-        #else
-        printf("%s: previous async cmd fail: result=%d\n", __func__, *result);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_lvb(request_idm, lvb, lvb_size);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_lvb fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_lvb fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_lvb(request_idm, lvb, lvb_size);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_lvb fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_lvb fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    #ifndef COMPILE_STANDALONE
-    ilm_log_array_dbg(" found: lvb", lvb, lvb_size);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_array_dbg(" found: lvb", lvb, lvb_size);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_async_lock - Asynchronously acquire an IDM on a specified NVMe drive.
+ * nvme_idm_async_lock - Asynchronously acquire an IDM on a specified NVMe
+ * drive.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -299,41 +323,41 @@ EXIT_FAIL:
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_async_lock(char *lock_id, int mode, char *host_id,
-                        char *drive, uint64_t timeout, uint64_t *handle) {
+                        char *drive, uint64_t timeout, uint64_t *handle)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm;
+	int ret = SUCCESS;  //TODO: Should ALL of these be initialized to FAILURE, instead of SUCCESS???  Probably going to be case-by-case
 
-    nvmeIdmRequest *request_idm;
-    int ret = SUCCESS;  //TODO: Should ALL of these be initialized to FAILURE, instead of SUCCESS???  Probably going to be case-by-case
+	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
@@ -352,45 +376,47 @@ EXIT:
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_async_lock_break(char *lock_id, int mode, char *host_id,
-                              char *drive, uint64_t timeout, uint64_t *handle) {
+                              char *drive, uint64_t timeout, uint64_t *handle)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm;
+	int ret = SUCCESS;
 
-    nvmeIdmRequest *request_idm;
-    int ret = SUCCESS;
+	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
+	                       &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock_break fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock_break fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _init_lock_break(lock_id, mode, host_id, drive, timeout, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock_break fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock_break fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_async_lock_convert - Asynchronously convert the lock mode for an IDM.
+ * nvme_idm_async_lock_convert - Asynchronously convert the lock mode for
+ * an IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -402,14 +428,16 @@ EXIT:
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_async_lock_convert(char *lock_id, int mode, char *host_id,
-                                char *drive, uint64_t timeout, uint64_t *handle)
+                                char *drive, uint64_t timeout,
+                                uint64_t *handle)
 {
-    return nvme_idm_async_lock_refresh(lock_id, mode, host_id,
-                                       drive, timeout, handle);
+	return nvme_idm_async_lock_refresh(lock_id, mode, host_id,
+	                                   drive, timeout, handle);
 }
 
 /**
- * nvme_idm_async_lock_destroy - Asynchronously destroy an IDM and release all associated resource.
+ * nvme_idm_async_lock_destroy - Asynchronously destroy an IDM and release
+ * all associated resource.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -422,43 +450,44 @@ int nvme_idm_async_lock_convert(char *lock_id, int mode, char *host_id,
 int nvme_idm_async_lock_destroy(char *lock_id, int mode, char *host_id,
                                 char *drive, uint64_t *handle)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int ret = SUCCESS;
 
-    ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock_destroy fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock_destroy fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock_destroy fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock_destroy fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_async_lock_refresh - Asynchronously refreshes the host's membership for an IDM.
+ * nvme_idm_async_lock_refresh - Asynchronously refreshes the host's
+ * membership for an IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -472,43 +501,45 @@ EXIT:
 int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
                                 char *drive, uint64_t timeout, uint64_t *handle)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int ret = SUCCESS;
 
-    ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock_refresh fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock_refresh fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
+	                         &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock_refresh fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock_refresh fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_async_lock_renew - Asynchronously renew host's membership for an IDM.
+ * nvme_idm_async_lock_renew - Asynchronously renew host's membership for
+ * an IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -522,14 +553,16 @@ EXIT:
 int nvme_idm_async_lock_renew(char *lock_id, int mode, char *host_id,
                               char *drive, uint64_t timeout, uint64_t *handle)
 {
-    return nvme_idm_async_lock_refresh(lock_id, mode, host_id,
-                                       drive, timeout, handle);
+	return nvme_idm_async_lock_refresh(lock_id, mode, host_id,
+	                                   drive, timeout, handle);
 }
 
 /**
- * nvme_idm_async_read_lock_count - Asynchrnously read the lock count for an IDM.
+ * nvme_idm_async_read_lock_count - Asynchrnously read the lock count for
+ * an IDM.
  * This command only issues the request.  It does NOT retrieve the data.
- * The desired data is returned during a separate call to nvme_idm_async_get_result_lock_count().
+ * The desired data is returned during a separate call to
+ * nvme_idm_async_get_result_lock_count().
  *
  * @lock_id:    Lock ID (64 bytes).
  * @host_id:    Host ID (32 bytes).
@@ -538,45 +571,49 @@ int nvme_idm_async_lock_renew(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive, uint64_t *handle) {
+int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive,
+                                   uint64_t *handle)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	ret = _init_read_lock_count(ASYNC_ON, lock_id, host_id, drive,
+					&request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_lock_count fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _init_read_lock_count fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _init_read_lock_count(ASYNC_ON, lock_id, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_lock_count fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_lock_count fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_async_read_lock_mode - Asynchronously read back an IDM's current mode.
+ * nvme_idm_async_read_lock_mode - Asynchronously read back an IDM's
+ * current mode.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @drive:      Drive path name.
@@ -584,46 +621,46 @@ EXIT:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle) {
+int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	ret = _init_read_lock_mode(ASYNC_ON, lock_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_lock_mode fail %d", __func__, ret);
+		#else
+		printf("%s: _init_read_lock_mode fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _init_read_lock_mode(ASYNC_ON, lock_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_lock_mode fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_lock_mode fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
-
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_async_read_lvb - Asynchronously read the lock value block(lvb) which is
- * associated to an IDM.
+ * nvme_idm_async_read_lvb - Asynchronously read the lock value block(lvb),
+ * which is associated to an IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -633,41 +670,42 @@ EXIT:
  *
  * Returns zero or a negative error (ie. EINVAL).
  */
-int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive, uint64_t *handle)
+int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive,
+                            uint64_t *handle)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    ret = _init_read_lvb(ASYNC_ON, lock_id, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_lvb fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_lvb fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_lvb(ASYNC_ON, lock_id, host_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_lvb fail %d", __func__, ret);
+		#else
+		printf("%s: _init_read_lvb fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
@@ -684,41 +722,44 @@ EXIT:
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_async_unlock(char *lock_id, int mode, char *host_id,
-                          char *lvb, int lvb_size, char *drive, uint64_t *handle)
+                          char *lvb, int lvb_size, char *drive,
+                          uint64_t *handle)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_unlock fail %d", __func__, ret);
-        #else
-        printf("%s: _init_unlock fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
+	                   &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_unlock fail %d", __func__, ret);
+		#else
+		printf("%s: _init_unlock fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_async_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_async_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_async_write fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    *handle = (uint64_t)request_idm;
-    goto EXIT;
+	*handle = (uint64_t)request_idm;
+	goto EXIT;
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
+	_memory_free_idm_request(request_idm);
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
@@ -729,9 +770,9 @@ EXIT:
  */
 int nvme_idm_get_fd(uint64_t handle)
 {
-    nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
+	nvmeIdmRequest *request_idm = (nvmeIdmRequest *)handle;
 
-    return request_idm->fd_nvme;
+	return request_idm->fd_nvme;
 }
 
 /**
@@ -743,12 +784,12 @@ int nvme_idm_get_fd(uint64_t handle)
  */
 int nvme_idm_read_version(int *version, char *drive)
 {
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: NOT IMPLEMENTED!!", __func__,);
-    #else
-    printf("%s: NOT IMPLEMENTED!!\n", __func__);
-    #endif //COMPILE_STANDALONE
-    return FAILURE;
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: NOT IMPLEMENTED!!", __func__,);
+	#else
+	printf("%s: NOT IMPLEMENTED!!\n", __func__);
+	#endif //COMPILE_STANDALONE
+	return FAILURE;
 }
 
 /**
@@ -763,37 +804,37 @@ int nvme_idm_read_version(int *version, char *drive)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_sync_lock(char *lock_id, int mode, char *host_id,
-                       char *drive, uint64_t timeout) {
+                       char *drive, uint64_t timeout)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmRequest *request_idm;
+	int ret = SUCCESS;
 
-    nvmeIdmRequest *request_idm;
-    int ret = SUCCESS;
+	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
-
-    ret = nvme_idm_sync_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-    }
+	ret = nvme_idm_sync_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
 EXIT:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
@@ -813,35 +854,36 @@ EXIT:
 int nvme_idm_sync_lock_break(char *lock_id, int mode, char *host_id,
                              char *drive, uint64_t timeout)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    ret = _init_lock_break(lock_id, mode, host_id, drive, timeout, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock_break fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock_break fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
+	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
+	                       &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock_break fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock_break fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    ret = nvme_idm_sync_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-    }
+	ret = nvme_idm_sync_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
 EXIT:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
@@ -858,12 +900,13 @@ EXIT:
 int nvme_idm_sync_lock_convert(char *lock_id, int mode, char *host_id,
                                char *drive, uint64_t timeout)
 {
-    return nvme_idm_sync_lock_refresh(lock_id, mode, host_id,
-                                      drive, timeout);
+	return nvme_idm_sync_lock_refresh(lock_id, mode, host_id,
+	                                  drive, timeout);
 }
 
 /**
- * nvme_idm_sync_lock_destroy - Synchronously destroy an IDM and release all associated resource.
+ * nvme_idm_sync_lock_destroy - Synchronously destroy an IDM and release all
+ * associated resources.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -872,41 +915,43 @@ int nvme_idm_sync_lock_convert(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id, char *drive)
+int nvme_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id,
+                               char *drive)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int ret = SUCCESS;
 
-    ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock_destroy fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock_destroy fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
+	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock_destroy fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock_destroy fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    ret = nvme_idm_sync_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-    }
+	ret = nvme_idm_sync_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
 EXIT:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_sync_lock_refresh - Synchronously refreshes the host's membership for an IDM.
+ * nvme_idm_sync_lock_refresh - Synchronously refreshes the host's membership
+ * for an IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -919,35 +964,36 @@ EXIT:
 int nvme_idm_sync_lock_refresh(char *lock_id, int mode, char *host_id,
                                   char *drive, uint64_t timeout)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_lock_refresh fail %d", __func__, ret);
-        #else
-        printf("%s: _init_lock_refresh fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
+	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
+	                         &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_lock_refresh fail %d", __func__, ret);
+		#else
+		printf("%s: _init_lock_refresh fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    ret = nvme_idm_sync_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-    }
+	ret = nvme_idm_sync_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
 EXIT:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
@@ -964,12 +1010,13 @@ EXIT:
 int nvme_idm_sync_lock_renew(char *lock_id, int mode, char *host_id,
                              char *drive, uint64_t timeout)
 {
-    return nvme_idm_sync_lock_refresh(lock_id, mode, host_id,
-                                      drive, timeout);
+	return nvme_idm_sync_lock_refresh(lock_id, mode, host_id,
+	                                  drive, timeout);
 }
 
 /**
- * nvme_idm_sync_read_host_state - Read back the host's state for an specific IDM.
+ * nvme_idm_sync_read_host_state - Read back the host's state for a
+ * specific IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @host_id:    Host ID (32 bytes).
@@ -979,59 +1026,63 @@ int nvme_idm_sync_lock_renew(char *lock_id, int mode, char *host_id,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_read_host_state(char *lock_id, char *host_id, int *host_state, char *drive)
+int nvme_idm_sync_read_host_state(char *lock_id, char *host_id,
+                                  int *host_state, char *drive)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    // Initialize the output
+	// Initialize the output
 //TODO: Does ALWAYS setting to -1 on failure make sense?
 //          Refer to scsi-side if removed.
 //          Was being set to -1 in a couple locations.
-    *host_state = -1;    //TODO: hardcoded state. add an "error" state to the enum?
+	*host_state = -1;    //TODO: hardcoded state. add an "error" state to the enum?
 
-    ret = _init_read_host_state(lock_id, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_host_state fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_host_state fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_host_state(lock_id, host_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_host_state fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _init_read_host_state fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_sync_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_sync_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_host_state(request_idm, host_state);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_host_state fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_host_state fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_host_state(request_idm, host_state);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_host_state fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_host_state fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: host_state=0x%X (%d)", __func__, *host_state, *host_state);
-    #else
-    printf("%s: found: host_state=0x%X (%d)\n", __func__, *host_state, *host_state);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: host_state=0x%X (%d)",
+	            __func__, *host_state, *host_state);
+	#else
+	printf("%s: found: host_state=0x%X (%d)\n",
+	       __func__, *host_state, *host_state);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
@@ -1047,65 +1098,71 @@ EXIT_FAIL:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count, int *self, char *drive)
+int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
+                                  int *self, char *drive)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    // Initialize the output
-    *count = 0;
-    *self  = 0;
+	// Initialize the output
+	*count = 0;
+	*self  = 0;
 
-    ret = _init_read_lock_count(ASYNC_OFF, lock_id, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_lock_count fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_lock_count fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_lock_count(ASYNC_OFF, lock_id, host_id, drive,
+	                            &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_lock_count fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _init_read_lock_count fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    if (!request_idm) {         //Occurs when mutex_num=0
-        return SUCCESS;
-    }
+	if (!request_idm) {	//Occurs when mutex_num=0
+		return SUCCESS;
+	}
 
-    ret = nvme_idm_sync_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_sync_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_lock_count(request_idm, count, self);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_lock_count fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_lock_count fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_lock_count(request_idm, count, self);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_lock_count fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_lock_count fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: lock_count=%d, self_count=%d", __func__, *count, *self);
-    #else
-    printf("%s: found: lock_count=%d, self_count=%d\n", __func__, *count, *self);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: lock_count=%d, self_count=%d",
+	            __func__, *count, *self);
+	#else
+	printf("%s: found: lock_count=%d, self_count=%d\n",
+	       __func__, *count, *self);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_sync_read_lock_mode - Synchronously read back an IDM's current mode.
+ * nvme_idm_sync_read_lock_mode - Synchronously read back an IDM's
+ * current mode.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Returned lock mode (unlock, shareable, exclusive).
@@ -1116,64 +1173,64 @@ EXIT_FAIL:
  */
 int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    // Initialize the output
-    *mode = -1;    //TODO: hardcoded state. add an "error" state to the enum?
+	// Initialize the output
+	*mode = -1;    //TODO: hardcoded state. add an "error" state to the enum?
 
-    ret = _init_read_lock_mode(ASYNC_OFF, lock_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_lock_mode fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_lock_mode fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_lock_mode(ASYNC_OFF, lock_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_lock_mode fail %d", __func__, ret);
+		#else
+		printf("%s: _init_read_lock_mode fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    if (!request_idm) {         //Occurs when mutex_num=0
-        *mode = IDM_MODE_UNLOCK;
-        return SUCCESS;
-    }
+	if (!request_idm) {         //Occurs when mutex_num=0
+		*mode = IDM_MODE_UNLOCK;
+		return SUCCESS;
+	}
 
-    ret = nvme_idm_sync_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_sync_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_lock_mode(request_idm, mode);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_lock_mode fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_lock_mode fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_lock_mode(request_idm, mode);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_lock_mode fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_lock_mode fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: mode=%d", __func__, *mode);
-    #else
-    printf("%s: found: mode=%d\n", __func__, *mode);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: mode=%d", __func__, *mode);
+	#else
+	printf("%s: found: mode=%d\n", __func__, *mode);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_sync_read_lvb - Synchronously read the lock value block(lvb) which is
- * associated to an IDM.
+ * nvme_idm_sync_read_lvb - Synchronously read the lock value block(lvb)
+ * which is associated to an IDM.
  *
  * @lock_id:    Lock ID (64 bytes).
  * @mode:       Lock mode (unlock, shareable, exclusive).
@@ -1185,65 +1242,67 @@ EXIT_FAIL:
  *
  * Returns zero or a negative error (ie. EINVAL).
  */
-int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size, char *drive)
+int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
+                           int lvb_size, char *drive)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    //TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
-    //However, this requires an IDM API parameter type change.
-    if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_LEN_BYTES))
-        return -EINVAL;
+	//TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
+	//However, this requires an IDM API parameter type change.
+	if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_LEN_BYTES))
+		return -EINVAL;
 
-    ret = _init_read_lvb(ASYNC_OFF, lock_id, host_id, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_lvb fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_lvb fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_lvb(ASYNC_OFF, lock_id, host_id, drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_lvb fail %d", __func__, ret);
+		#else
+		printf("%s: _init_read_lvb fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    if (!request_idm) {         //Occurs when mutex_num=0
-        memset(lvb, 0x0, lvb_size);
-        return SUCCESS;
-    }
+	if (!request_idm) {	//Occurs when mutex_num=0
+		memset(lvb, 0x0, lvb_size);
+		return SUCCESS;
+	}
 
-    ret = nvme_idm_sync_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_sync_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_lvb(request_idm, lvb, lvb_size);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_lvb fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_lvb fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_lvb(request_idm, lvb, lvb_size);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_lvb fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_lvb fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_array_dbg(" found: lvb", lvb, lvb_size);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_array_dbg(" found: lvb", lvb, lvb_size);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * nvme_idm_sync_read_mutex_group - Synchronously read back mutex group info for all IDM in the drives
+ * nvme_idm_sync_read_mutex_group - Synchronously read back mutex group info
+ * for all IDM in the drives
  *
  * @drive:      Drive path name.
  * @info_ptr:   Returned pointer for info list.
@@ -1253,60 +1312,62 @@ EXIT_FAIL:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr, int *info_num)
+int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
+                                   int *info_num)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    // Initialize the output
-    *info_ptr = NULL;
-    *info_num = 0;
+	// Initialize the output
+	*info_ptr = NULL;
+	*info_num = 0;
 
-    ret = _init_read_mutex_group(drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_mutex_group fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_mutex_group fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_mutex_group(drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_mutex_group fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _init_read_mutex_group fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_sync_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = nvme_idm_sync_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = _parse_mutex_group(request_idm, info_ptr, info_num);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _parse_mutex_group fail %d", __func__, ret);
-        #else
-        printf("%s: _parse_mutex_group fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _parse_mutex_group(request_idm, info_ptr, info_num);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _parse_mutex_group fail %d", __func__, ret);
+		#else
+		printf("%s: _parse_mutex_group fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    //TODO: Keep -OR- Add debug flag??
-    dumpIdmInfoStruct(*info_ptr);
+	//TODO: Keep -OR- Add debug flag??
+	dumpIdmInfoStruct(*info_ptr);
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: info_num=%d", __func__, *info_num);
-    #else
-    printf("%s: found: info_num=%d\n", __func__, *info_num);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: info_num=%d", __func__, *info_num);
+	#else
+	printf("%s: found: info_num=%d\n", __func__, *info_num);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
@@ -1322,50 +1383,51 @@ EXIT_FAIL:
  */
 int nvme_idm_sync_read_mutex_num(char *drive, unsigned int *mutex_num)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
 //TODO: The SCSI-side code tends to set this to 0 on certain failures.
 //          Does ALWAYS setting to 0 on failure HERE make sense (this is a bit different from scsi-side?
-    *mutex_num = 0;
+	*mutex_num = 0;
 
-    ret = _init_read_mutex_num(drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_read_mutex_num fail %d", __func__, ret);
-        #else
-        printf("%s: _init_read_mutex_num fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT_FAIL;
-    }
+	ret = _init_read_mutex_num(drive, &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_read_mutex_num fail %d", __func__, ret);
+		#else
+		printf("%s: _init_read_mutex_num fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT_FAIL;
+	}
 
-    ret = nvme_idm_sync_read(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-        goto EXIT_FAIL;
-        #else
+	ret = nvme_idm_sync_read(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
+		goto EXIT_FAIL;
+		#else
 //TODO: !!!! Temp HACK!!!!! For stand alone, to get the reads working.
 	//WARNING: This is realted to the FORCE_MUTEX_NUM compile flag as well
-        printf("%s: nvme_idm_sync_read fail %d, Continuing\n", __func__, ret);
-        ret = SUCCESS;
-        #endif //COMPILE_STANDALONE
-    }
+		printf("%s: nvme_idm_sync_read fail %d, Continuing\n",
+		       __func__, ret);
+		ret = SUCCESS;
+		#endif //COMPILE_STANDALONE
+	}
 
-    _parse_mutex_num(request_idm, mutex_num);
+	_parse_mutex_num(request_idm, mutex_num);
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: found: mutex_num=%d", __func__, *mutex_num);
-    #else
-    printf("%s: found: mutex_num=%d\n", __func__, *mutex_num);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: found: mutex_num=%d", __func__, *mutex_num);
+	#else
+	printf("%s: found: mutex_num=%d\n", __func__, *mutex_num);
+	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
@@ -1383,94 +1445,100 @@ EXIT_FAIL:
 int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
                          char *lvb, int lvb_size, char *drive)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    nvmeIdmRequest *request_idm;
-    int            ret = SUCCESS;
+	nvmeIdmRequest *request_idm;
+	int            ret = SUCCESS;
 
-    ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive, &request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _init_unlock fail %d", __func__, ret);
-        #else
-        printf("%s: _init_unlock fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
+	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
+	                   &request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _init_unlock fail %d", __func__, ret);
+		#else
+		printf("%s: _init_unlock fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    ret = nvme_idm_sync_write(request_idm);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-    }
+	ret = nvme_idm_sync_write(request_idm);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
 EXIT:
-    _memory_free_idm_request(request_idm);
-    return ret;
+	_memory_free_idm_request(request_idm);
+	return ret;
 }
 
 /**
- * _init_lock - Convenience function containing common code for the IDM lock action.
+ * _init_lock - Convenience function containing common code for the
+ * IDM lock action.
  *
  * @lock_id:     Lock ID (64 bytes).
  * @mode:        Lock mode (unlock, shareable, exclusive).
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
  * @timeout:     Timeout for membership (unit: millisecond).
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
-               uint64_t timeout, nvmeIdmRequest **request_idm) {
+               uint64_t timeout, nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _validate_input_write(lock_id, mode, host_id, drive);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _validate_input_write fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _validate_input_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _validate_input_write(lock_id, mode, host_id, drive);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _validate_input_write fail %d", __func__, ret);
-        #else
-        printf("%s: _validate_input_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _memory_init_idm_request fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _memory_init_idm_request fail %d\n",
+		       __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _memory_init_idm_request fail %d", __func__, ret);
-        #else
-        printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
+	                          (*request_idm));
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, (*request_idm));
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	//API-specific code
+	(*request_idm)->opcode_idm   = IDM_OPCODE_TRYLOCK;
+	(*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    //API-specific code
-    (*request_idm)->opcode_idm   = IDM_OPCODE_TRYLOCK;
-    (*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
-
-    return ret;
+	return ret;
 }
 
 /**
@@ -1482,55 +1550,59 @@ int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
  * @timeout:     Timeout for membership (unit: millisecond).
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
-                     uint64_t timeout, nvmeIdmRequest **request_idm) {
+                     uint64_t timeout, nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _validate_input_write(lock_id, mode, host_id, drive);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _validate_input_write fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _validate_input_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _validate_input_write(lock_id, mode, host_id, drive);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _validate_input_write fail %d", __func__, ret);
-        #else
-        printf("%s: _validate_input_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _memory_init_idm_request fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _memory_init_idm_request fail %d\n",
+		       __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _memory_init_idm_request fail %d", __func__, ret);
-        #else
-        printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
+	                          (*request_idm));
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, (*request_idm));
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	//API-specific code
+	(*request_idm)->opcode_idm   = IDM_OPCODE_BREAK;
+	(*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    //API-specific code
-    (*request_idm)->opcode_idm   = IDM_OPCODE_BREAK;
-    (*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
-
-    return ret;
+	return ret;
 }
 
 /**
@@ -1541,55 +1613,59 @@ int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
  * @mode:        Lock mode (unlock, shareable, exclusive).
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
-                       nvmeIdmRequest **request_idm) {
+                       nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _validate_input_write(lock_id, mode, host_id, drive);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _validate_input_write fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _validate_input_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _validate_input_write(lock_id, mode, host_id, drive);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _validate_input_write fail %d", __func__, ret);
-        #else
-        printf("%s: _validate_input_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _memory_init_idm_request fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _memory_init_idm_request fail %d\n",
+		       __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _memory_init_idm_request fail %d", __func__, ret);
-        #else
-        printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0,
+	                          (*request_idm));
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0, (*request_idm));
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	//API-specific code
+	(*request_idm)->opcode_idm   = IDM_OPCODE_DESTROY;
+	(*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    //API-specific code
-    (*request_idm)->opcode_idm   = IDM_OPCODE_DESTROY;
-    (*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
-
-    return ret;
+	return ret;
 }
 
 /**
@@ -1601,392 +1677,397 @@ int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
  * @timeout:     Timeout for membership (unit: millisecond).
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
-                       uint64_t timeout, nvmeIdmRequest **request_idm) {
+                       uint64_t timeout, nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _validate_input_write(lock_id, mode, host_id, drive);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _validate_input_write fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _validate_input_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _validate_input_write(lock_id, mode, host_id, drive);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _validate_input_write fail %d", __func__, ret);
-        #else
-        printf("%s: _validate_input_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _memory_init_idm_request fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _memory_init_idm_request fail %d\n",
+		       __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _memory_init_idm_request fail %d", __func__, ret);
-        #else
-        printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
+	                          (*request_idm));
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout, (*request_idm));
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	//API-specific code
+	(*request_idm)->opcode_idm   = IDM_OPCODE_REFRESH;
+	(*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
 
-    //API-specific code
-    (*request_idm)->opcode_idm   = IDM_OPCODE_REFRESH;
-    (*request_idm)->res_ver_type = (char)IDM_RES_VER_NO_UPDATE_NO_VALID;
-
-    return ret;
+	return ret;
 }
 
 /**
- * _init_read_host_state - Convenience function containing common code for the retrieval
- * of the IDM host state from the drive.
+ * _init_read_host_state - Convenience function containing common code for
+ * the retrieval of the IDM host state from the drive.
  *
  * @lock_id:     Lock ID (64 bytes).
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_host_state(char *lock_id, char *host_id, char *drive,
-                          nvmeIdmRequest **request_idm) {
+                          nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	unsigned int   mutex_num = 0;
+	int            ret       = SUCCESS;
 
-    unsigned int   mutex_num = 0;
-    int            ret       = SUCCESS;
+	ret = _validate_input_common(lock_id, host_id, drive);
+	if (ret < 0)
+		return ret;
 
-    ret = _validate_input_common(lock_id, host_id, drive);
-    if (ret < 0)
-        return ret;
+	ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
+	if (ret < 0)
+		return -ENOENT;
+	else if (!mutex_num)
+		return SUCCESS;
 
-    ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
-    if (ret < 0)
-        return -ENOENT;
-    else if (!mutex_num)
-        return SUCCESS;
+	ret = _memory_init_idm_request(request_idm, mutex_num);
+	if (ret < 0)
+		return ret;
 
-    ret = _memory_init_idm_request(request_idm, mutex_num);
-    if (ret < 0)
-        return ret;
+	nvme_idm_read_init(drive, *request_idm);
 
-    nvme_idm_read_init(drive, *request_idm);
+	//API-specific code
+	(*request_idm)->group_idm = IDM_GROUP_DEFAULT;
+	memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
+	memcpy((*request_idm)->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
 
-    //API-specific code
-    (*request_idm)->group_idm = IDM_GROUP_DEFAULT;
-    memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
-    memcpy((*request_idm)->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
-
-    return ret;
+	return ret;
 }
 
 /**
- * _init_read_lock_count - Convenience function containing common code for the retrieval
- * of the IDM lock count from the drive.
+ * _init_read_lock_count - Convenience function containing common code for the
+ * retrieval of the IDM lock count from the drive.
  *
  * @async_on:    Boolean flag indicating async(1) or sync(0) wrapping function.
  *               Async and sync usage have different control flows.
  * @lock_id:     Lock ID (64 bytes).
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _init_read_lock_count(int async_on, char *lock_id, char *host_id, char *drive,
-                          nvmeIdmRequest **request_idm) {
+int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
+                          char *drive, nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	unsigned int   mutex_num = 0;
+	int            ret       = SUCCESS;
 
-    unsigned int   mutex_num = 0;
-    int            ret       = SUCCESS;
+	ret = _validate_input_common(lock_id, host_id, drive);
+	if (ret < 0)
+		return ret;
 
-    ret = _validate_input_common(lock_id, host_id, drive);
-    if (ret < 0)
-        return ret;
+	ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
+	if (ret < 0)
+		return -ENOENT;
+	else if (!mutex_num)
+		return SUCCESS;
 
-    ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
-    if (ret < 0)
-        return -ENOENT;
-    else if (!mutex_num)
-        return SUCCESS;
+	if (async_on) {
+		/*
+		* We know there have no any mutex entry in the drive,
+		* the async opertion is devided into two steps: send
+		* the async operation and get the async result.
+		*
+		* In this step, if we directly return success with
+		* count '0', the raid thread will poll forever.  This
+		* is the reason we proceed to send SCSI command to
+		* read back 1 data block and defer to return count.
+		*/
+		if (!mutex_num)
+		mutex_num = 1;
+	}
+	else {
+		if (!mutex_num) {
+		request_idm = NULL;
+		return SUCCESS;
+		}
+	}
 
-    if (async_on) {
-        /*
-        * We know there have no any mutex entry in the drive,
-        * the async opertion is devided into two steps: send
-        * the async operation and get the async result.
-        *
-        * In this step, if we directly return success with
-        * count '0', the raid thread will poll forever.  This
-        * is the reason we proceed to send SCSI command to
-        * read back 1 data block and defer to return count.
-        */
-        if (!mutex_num)
-            mutex_num = 1;
-    }
-    else {
-        if (!mutex_num) {
-            request_idm = NULL;
-            return SUCCESS;
-        }
-    }
+	ret = _memory_init_idm_request(request_idm, mutex_num);
+	if (ret < 0)
+		return ret;
 
-    ret = _memory_init_idm_request(request_idm, mutex_num);
-    if (ret < 0)
-        return ret;
+	nvme_idm_read_init(drive, *request_idm);
 
-    nvme_idm_read_init(drive, *request_idm);
+	//API-specific code
+	(*request_idm)->group_idm = IDM_GROUP_DEFAULT;
+	memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
+	memcpy((*request_idm)->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
 
-    //API-specific code
-    (*request_idm)->group_idm = IDM_GROUP_DEFAULT;
-    memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
-    memcpy((*request_idm)->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
-
-    return ret;
+	return ret;
 }
 
 /**
- * _init_read_lock_mode - Convenience function containing common code for the retrieval
- * of the IDM lock mode from the drive.
+ * _init_read_lock_mode - Convenience function containing common code for the
+ * retrieval of the IDM lock mode from the drive.
  *
  * @async_on:    Boolean flag indicating async(1) or sync(0) wrapping function.
  *               Async and sync usage have different control flows.
  * @lock_id:     Lock ID (64 bytes).
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
-                         nvmeIdmRequest **request_idm) {
+                         nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	unsigned int   mutex_num = 0;
+	int            ret       = SUCCESS;
 
-    unsigned int   mutex_num = 0;
-    int            ret       = SUCCESS;
+	#ifndef COMPILE_STANDALONE
+	if (ilm_inject_fault_is_hit())
+		return -EIO;
+	#endif //COMPILE_STANDALONE
 
-    #ifndef COMPILE_STANDALONE
-    if (ilm_inject_fault_is_hit())
-        return -EIO;
-    #endif //COMPILE_STANDALONE
+	if (!lock_id || !drive)
+		return -EINVAL;
 
-    if (!lock_id || !drive)
-        return -EINVAL;
+	ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
+	if (ret < 0)
+		return -ENOENT;
 
-    ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
-    if (ret < 0)
-        return -ENOENT;
+	if (async_on) {
+		/*
+		* We know there have no any mutex entry in the drive,
+		* the async opertion is devided into two steps: send
+		* the async operation and get the async result.
+		*
+		* In this step, if we directly return success with
+		* count '0', the raid thread will poll forever.  This
+		* is the reason we proceed to send SCSI command to
+		* read back 1 data block and defer to return count.
+		*/
+		if (!mutex_num)
+		mutex_num = 1;
+	}
+	else {
+		if (!mutex_num) {
+		request_idm = NULL;
+		return SUCCESS;
+		}
+	}
 
-    if (async_on) {
-        /*
-        * We know there have no any mutex entry in the drive,
-        * the async opertion is devided into two steps: send
-        * the async operation and get the async result.
-        *
-        * In this step, if we directly return success with
-        * count '0', the raid thread will poll forever.  This
-        * is the reason we proceed to send SCSI command to
-        * read back 1 data block and defer to return count.
-        */
-        if (!mutex_num)
-            mutex_num = 1;
-    }
-    else {
-        if (!mutex_num) {
-            request_idm = NULL;
-            return SUCCESS;
-        }
-    }
+	ret = _memory_init_idm_request(request_idm, mutex_num);
+	if (ret < 0)
+		return ret;
 
-    ret = _memory_init_idm_request(request_idm, mutex_num);
-    if (ret < 0)
-        return ret;
+	nvme_idm_read_init(drive, *request_idm);
 
-    nvme_idm_read_init(drive, *request_idm);
+	//API-specific code
+	(*request_idm)->group_idm = IDM_GROUP_DEFAULT;
+	memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
 
-    //API-specific code
-    (*request_idm)->group_idm = IDM_GROUP_DEFAULT;
-    memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
-
-    return ret;
+	return ret;
 }
 
 /**
- * _init_read_lvb - Convenience function containing common code for the retrieval
- * of the lock value block(lvb) from the drive.
+ * _init_read_lvb - Convenience function containing common code for the
+ * retrieval of the lock value block(lvb) from the drive.
  *
  * @async_on:    Boolean flag indicating async(1) or sync(0) wrapping function.
  *               Async and sync usage have different control flows.
  * @lock_id:     Lock ID (64 bytes).
  * @host_id:     Host ID (32 bytes).
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
-                   nvmeIdmRequest **request_idm) {
+                   nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	unsigned int   mutex_num = 0;
+	int            ret = SUCCESS;
 
-    unsigned int   mutex_num = 0;
-    int            ret = SUCCESS;
+	ret = _validate_input_common(lock_id, host_id, drive);
+	if (ret < 0)
+		return ret;
 
-    ret = _validate_input_common(lock_id, host_id, drive);
-    if (ret < 0)
-        return ret;
+	ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
+	if (ret < 0)
+		return -ENOENT;
 
-    ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
-    if (ret < 0)
-        return -ENOENT;
+	if (async_on) {
+		/*
+		* We know there have no any mutex entry in the drive,
+		* the async opertion is devided into two steps: send
+		* the async operation and get the async result.
+		*
+		* In this step, if we directly return success with
+		* count '0', the raid thread will poll forever.  This
+		* is the reason we proceed to send SCSI command to
+		* read back 1 data block and defer to return count.
+		*/
+		if (!mutex_num)
+		mutex_num = 1;
+	}
+	else {
+		if (!mutex_num) {
+		request_idm = NULL;
+		return SUCCESS;
+		}
+	}
 
-    if (async_on) {
-        /*
-        * We know there have no any mutex entry in the drive,
-        * the async opertion is devided into two steps: send
-        * the async operation and get the async result.
-        *
-        * In this step, if we directly return success with
-        * count '0', the raid thread will poll forever.  This
-        * is the reason we proceed to send SCSI command to
-        * read back 1 data block and defer to return count.
-        */
-        if (!mutex_num)
-            mutex_num = 1;
-    }
-    else {
-        if (!mutex_num) {
-            request_idm = NULL;
-            return SUCCESS;
-        }
-    }
+	ret = _memory_init_idm_request(request_idm, mutex_num);
+	if (ret < 0)
+		return ret;
 
-    ret = _memory_init_idm_request(request_idm, mutex_num);
-    if (ret < 0)
-        return ret;
+	nvme_idm_read_init(drive, *request_idm);
 
-    nvme_idm_read_init(drive, *request_idm);
+	//API-specific code
+	(*request_idm)->group_idm = IDM_GROUP_DEFAULT;
+	memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
+	memcpy((*request_idm)->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
 
-    //API-specific code
-    (*request_idm)->group_idm = IDM_GROUP_DEFAULT;
-    memcpy((*request_idm)->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
-    memcpy((*request_idm)->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
-
-    return ret;
+	return ret;
 }
 
 /**
- * _init_read_mutex_group - Convenience function containing common code for the retrieval
- * of IDM group information from the drive.
+ * _init_read_mutex_group - Convenience function containing common code for
+ * the retrieval of IDM group information from the drive.
  *
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _init_read_mutex_group(char *drive, nvmeIdmRequest **request_idm) {
+int _init_read_mutex_group(char *drive, nvmeIdmRequest **request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	unsigned int mutex_num = 0;
+	int          ret       = SUCCESS;
 
-    unsigned int mutex_num = 0;
-    int          ret       = SUCCESS;
+	#ifndef COMPILE_STANDALONE
+	if (ilm_inject_fault_is_hit())
+		return -EIO;
+	#endif //COMPILE_STANDALONE
 
-    #ifndef COMPILE_STANDALONE
-    if (ilm_inject_fault_is_hit())
-        return -EIO;
-    #endif //COMPILE_STANDALONE
+	if (!drive)
+		return -EINVAL;
 
-    if (!drive)
-        return -EINVAL;
+	ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
+	if (ret < 0)
+		return -ENOENT;
+	else if (!mutex_num)
+		return SUCCESS;
 
-    ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
-    if (ret < 0)
-        return -ENOENT;
-    else if (!mutex_num)
-        return SUCCESS;
+	ret = _memory_init_idm_request(request_idm, mutex_num);
+	if (ret < 0)
+		return ret;
 
-    ret = _memory_init_idm_request(request_idm, mutex_num);
-    if (ret < 0)
-        return ret;
+	nvme_idm_read_init(drive, *request_idm);
 
-    nvme_idm_read_init(drive, *request_idm);
+	//API-specific code
+	(*request_idm)->group_idm = IDM_GROUP_DEFAULT;
 
-    //API-specific code
-    (*request_idm)->group_idm = IDM_GROUP_DEFAULT;
-
-    return ret;
+	return ret;
 }
 
 /**
- * _init_read_mutex_num - Convenience function containing common code for the retrieval
- * of the number of lock mutexes available on the device.
+ * _init_read_mutex_num - Convenience function containing common code for the
+ * retrieval of the number of lock mutexes available on the device.
  *
  * @drive:       Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int _init_read_mutex_num(char *drive, nvmeIdmRequest **request_idm)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    int ret = SUCCESS;
+	int ret = SUCCESS;
 
-    #ifndef COMPILE_STANDALONE
-    if (ilm_inject_fault_is_hit())
-        return -EIO;
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	if (ilm_inject_fault_is_hit())
+		return -EIO;
+	#endif //COMPILE_STANDALONE
 
-    ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _memory_init_idm_request fail %d", __func__, ret);
-        #else
-        printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _memory_init_idm_request fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    nvme_idm_read_init(drive, *request_idm);
+	nvme_idm_read_init(drive, *request_idm);
 
-    //API-specific code
-    (*request_idm)->group_idm = IDM_GROUP_INQUIRY;
+	//API-specific code
+	(*request_idm)->group_idm = IDM_GROUP_INQUIRY;
 
-    return ret;
+	return ret;
 }
 
 /**
@@ -1999,142 +2080,150 @@ int _init_read_mutex_num(char *drive, nvmeIdmRequest **request_idm)
  * @lvb:        Lock value block pointer.
  * @lvb_size:   Lock value block size.
  * @drive:      Drive path name.
- * @request_idm: Returned struct containing all NVMe-specific command info for the
- *               requested IDM action.
+ * @request_idm: Returned struct containing all NVMe-specific command info for
+ *               the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size,
-                 char *drive, nvmeIdmRequest **request_idm)
+int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
+                 int lvb_size, char *drive, nvmeIdmRequest **request_idm)
 {
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    int ret = SUCCESS;
+	int ret = SUCCESS;
 
-    //TODO: The -ve check here should go away cuz lvb_size should be of unsigned type.
-    //However, this requires an IDM API parameter type change.
-    if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_LEN_BYTES))
-        return -EINVAL;
+	//TODO: The -ve check here should go away cuz lvb_size should be of unsigned type.
+	//However, this requires an IDM API parameter type change.
+	if ((!lvb) || (lvb_size <= 0) || (lvb_size > IDM_LVB_LEN_BYTES))
+		return -EINVAL;
 
-    ret = _validate_input_write(lock_id, mode, host_id, drive);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _validate_input_write fail %d", __func__, ret);
-        #else
-        printf("%s: _validate_input_write fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _validate_input_write(lock_id, mode, host_id, drive);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _validate_input_write fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _validate_input_write fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _memory_init_idm_request fail %d", __func__, ret);
-        #else
-        printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _memory_init_idm_request fail %d",
+		            __func__, ret);
+		#else
+		printf("%s: _memory_init_idm_request fail %d\n",
+		       __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    //TODO: Why 0 timeout here (ported as-is from scsi-side)?
-    ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0, (*request_idm));
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-        #else
-        printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-        return ret;
-    }
+	//TODO: Why 0 timeout here (ported as-is from scsi-side)?
+	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0,
+	                          (*request_idm));
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
+		#else
+		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+		return ret;
+	}
 
-    //API-specific code
-    (*request_idm)->opcode_idm   = IDM_OPCODE_UNLOCK;
-    (*request_idm)->res_ver_type = (char)IDM_RES_VER_UPDATE_NO_VALID;
-    memcpy((*request_idm)->lvb, lvb, lvb_size);
+	//API-specific code
+	(*request_idm)->opcode_idm   = IDM_OPCODE_UNLOCK;
+	(*request_idm)->res_ver_type = (char)IDM_RES_VER_UPDATE_NO_VALID;
+	memcpy((*request_idm)->lvb, lvb, lvb_size);
 
-    return ret;
+	return ret;
 }
 
 /**
- * _memory_free_idm_request - Convenience function for freeing memory for all the
- * data structures used during the NVMe command sequence.
+ * _memory_free_idm_request - Convenience function for freeing memory for all
+ * the data structures used during the NVMe command sequence.
  *
- * @request_idm: Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm: Struct containing all NVMe-specific command info for the
+ *               requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 void _memory_free_idm_request(nvmeIdmRequest *request_idm) {
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    if (request_idm->data_idm) {
-        free(request_idm->data_idm);
-        request_idm->data_idm = NULL;
-    }
-    if (request_idm) {
-        free(request_idm);
-        request_idm = NULL;
-    }
+	if (request_idm->data_idm) {
+		free(request_idm->data_idm);
+		request_idm->data_idm = NULL;
+	}
+	if (request_idm) {
+		free(request_idm);
+		request_idm = NULL;
+	}
 }
 
 /**
- * _memory_init_idm_request - Convenience function for allocating memory for all the
- *  data structures used during the NVMe command sequence.
+ * _memory_init_idm_request - Convenience function for allocating memory for
+ * all the data structures used during the NVMe command sequence.
  *
- * @request_idm: Struct containing all NVMe-specific command info for the requested IDM action.
- *               Note: **request_idm is due to malloc() needing access to the original pointer.
+ * @request_idm: Struct containing all NVMe-specific command info for the
+ *               requested IDM action.
+ *               Note: **request_idm is due to malloc() needing access to
+ *               the original pointer.
  * @data_num:    Number of data payload instances that need memory allocation.
  *               Also corresponds to the number of mutexes on the drive.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _memory_init_idm_request(nvmeIdmRequest **request_idm, unsigned int data_num) {
+int _memory_init_idm_request(nvmeIdmRequest **request_idm,
+                             unsigned int data_num)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int data_len;
+	int ret = SUCCESS;
 
-    int data_len;
-    int ret = SUCCESS;
+	*request_idm = malloc(sizeof(nvmeIdmRequest));
+	if (!request_idm) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: request memory allocate fail", __func__);
+		#else
+		printf("%s: request memory allocate fail\n", __func__);
+		#endif //COMPILE_STANDALONE
+		return -ENOMEM;
+	}
+	memset((*request_idm), 0, sizeof(**request_idm));
 
-    *request_idm = malloc(sizeof(nvmeIdmRequest));
-    if (!request_idm) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: request memory allocate fail", __func__);
-        #else
-        printf("%s: request memory allocate fail\n", __func__);
-        #endif //COMPILE_STANDALONE
-        return -ENOMEM;
-    }
-    memset((*request_idm), 0, sizeof(**request_idm));
+	data_len                 = sizeof(idmData) * data_num;
+	(*request_idm)->data_idm = malloc(data_len);
+	if (!(*request_idm)->data_idm) {
+		_memory_free_idm_request((*request_idm));
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: request data memory allocate fail", __func__);
+		#else
+		printf("%s: request data memory allocate fail\n", __func__);
+		#endif //COMPILE_STANDALONE
+		return -ENOMEM;
+	}
+	memset((*request_idm)->data_idm, 0, data_len);
 
-    data_len                 = sizeof(idmData) * data_num;
-    (*request_idm)->data_idm = malloc(data_len);
-    if (!(*request_idm)->data_idm) {
-        _memory_free_idm_request((*request_idm));
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: request data memory allocate fail", __func__);
-        #else
-        printf("%s: request data memory allocate fail\n", __func__);
-        #endif //COMPILE_STANDALONE
-        return -ENOMEM;
-    }
-    memset((*request_idm)->data_idm, 0, data_len);
+	//Cache memory-specifc info.
+	(*request_idm)->data_len = data_len;
+	(*request_idm)->data_num = data_num;
 
-    //Cache memory-specifc info.
-    (*request_idm)->data_len = data_len;
-    (*request_idm)->data_num = data_num;
-
-    return ret;
+	return ret;
 }
 
 /**
- * _parse_host_state - Convenience function for parsing the host state out of the
- * returned data payload.
+ * _parse_host_state - Convenience function for parsing the host state out of
+ * the returned data payload.
  *
  * @request_idm: Struct containing all NVMe-specific command info for the
  *               requested IDM action.
@@ -2143,57 +2232,63 @@ int _memory_init_idm_request(nvmeIdmRequest **request_idm, unsigned int data_num
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state) {
+int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	idmData        *data_idm;
+	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
+	int            i;
+	unsigned int   mutex_num = request_idm->data_num;
+	int            ret       = SUCCESS;
 
-    idmData        *data_idm;
-    char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-    char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
-    int            i;
-    unsigned int   mutex_num = request_idm->data_num;
-    int            ret       = SUCCESS;
+	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
+	               IDM_LOCK_ID_LEN_BYTES);
+	bswap_char_arr(bswap_host_id, request_idm->host_id,
+	               IDM_HOST_ID_LEN_BYTES);
 
-    bswap_char_arr(bswap_lock_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
-    bswap_char_arr(bswap_host_id, request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
+	data_idm = request_idm->data_idm;
+	for (i = 0; i < mutex_num; i++) {
+		#ifndef COMPILE_STANDALONE
+		//TODO: Layout improvement over adhereing to 80 char limit??
+		ilm_log_array_dbg("resource_id",  data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
+		ilm_log_array_dbg("lock_id",      bswap_lock_id,           IDM_LOCK_ID_LEN_BYTES);
+		ilm_log_array_dbg("data host_id", data_idm[i].host_id,     IDM_HOST_ID_LEN_BYTES);
+		ilm_log_array_dbg("host_id",      bswap_host_id,           IDM_HOST_ID_LEN_BYTES);
+		#else
+		printf("bswap_lock_id    = '");
+		_print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
+		printf("data resource_id = '");
+		_print_char_arr(data_idm[i].resource_id,
+		                IDM_LOCK_ID_LEN_BYTES);
+		printf("bswap_host_id = '");
+		_print_char_arr(bswap_host_id, IDM_HOST_ID_LEN_BYTES);
+		printf("data host_id  = '");
+		_print_char_arr(data_idm[i].host_id, IDM_HOST_ID_LEN_BYTES);
+		#endif //COMPILE_STANDALONE
 
-    data_idm = request_idm->data_idm;
-    for (i = 0; i < mutex_num; i++) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_array_dbg("resource_id",  data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        ilm_log_array_dbg("lock_id",      bswap_lock_id,           IDM_LOCK_ID_LEN_BYTES);
-        ilm_log_array_dbg("data host_id", data_idm[i].host_id,     IDM_HOST_ID_LEN_BYTES);
-        ilm_log_array_dbg("host_id",      bswap_host_id,           IDM_HOST_ID_LEN_BYTES);
-        #else
-        printf("bswap_lock_id    = '");
-        _print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
-        printf("data resource_id = '");
-        _print_char_arr(data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        printf("bswap_host_id = '");
-        _print_char_arr(bswap_host_id, IDM_HOST_ID_LEN_BYTES);
-        printf("data host_id  = '");
-        _print_char_arr(data_idm[i].host_id, IDM_HOST_ID_LEN_BYTES);
-        #endif //COMPILE_STANDALONE
+		/* Skip for other locks */
+		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
+		           IDM_LOCK_ID_LEN_BYTES))
+			continue;
 
-        /* Skip for other locks */
-        if (memcmp(data_idm[i].resource_id, bswap_lock_id, IDM_LOCK_ID_LEN_BYTES))
-            continue;
+		if (memcmp(data_idm[i].host_id, bswap_host_id,
+		           IDM_HOST_ID_LEN_BYTES))
+			continue;
 
-        if (memcmp(data_idm[i].host_id, bswap_host_id, IDM_HOST_ID_LEN_BYTES))
-            continue;
+		*host_state = __bswap_64(data_idm[i].state);
+		break;
+	}
 
-        *host_state = __bswap_64(data_idm[i].state);
-        break;
-    }
-
-    return ret;
+	return ret;
 }
 
 /**
- * _parse_lock_count - Convenience function for parsing the lock count out of the
- * returned data payload.
+ * _parse_lock_count - Convenience function for parsing the lock count out of
+ * the returned data payload.
  *
  * @request_idm: Struct containing all NVMe-specific command info for the
  *               requested IDM action.
@@ -2204,71 +2299,82 @@ int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state) {
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_lock_count(nvmeIdmRequest *request_idm, int *count, int *self) {
+int _parse_lock_count(nvmeIdmRequest *request_idm, int *count, int *self)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	idmData        *data_idm;
+	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
+	int            i;
+	unsigned int   mutex_num = request_idm->data_num;
+	int            ret = SUCCESS;
+	uint64_t       state, locked;
 
-    idmData        *data_idm;
-    char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-    char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
-    int            i;
-    unsigned int   mutex_num = request_idm->data_num;
-    int            ret = SUCCESS;
-    uint64_t       state, locked;
+	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
+	               IDM_LOCK_ID_LEN_BYTES);
+	bswap_char_arr(bswap_host_id, request_idm->host_id,
+	               IDM_HOST_ID_LEN_BYTES);
 
-    bswap_char_arr(bswap_lock_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
-    bswap_char_arr(bswap_host_id, request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
+	data_idm = request_idm->data_idm;
+	for (i = 0; i < mutex_num; i++) {
 
-    data_idm = request_idm->data_idm;
-    for (i = 0; i < mutex_num; i++) {
+		state  = __bswap_64(data_idm[i].state);
+		locked = (state == IDM_STATE_LOCKED) ||
+		         (state == IDM_STATE_MULTIPLE_LOCKED);
 
-        state  = __bswap_64(data_idm[i].state);
-        locked = (state == IDM_STATE_LOCKED) || (state == IDM_STATE_MULTIPLE_LOCKED);
+		if (!locked)
+			continue;
 
-        if (!locked)
-            continue;
+		#ifndef COMPILE_STANDALONE
+		ilm_log_array_dbg("resource_id", data_idm[i].resource_id,
+		                  IDM_LOCK_ID_LEN_BYTES);
+		ilm_log_array_dbg("lock_id", bswap_lock_id,
+		                  IDM_LOCK_ID_LEN_BYTES);
+		ilm_log_array_dbg("data host_id", data_idm[i].host_id,
+		                  IDM_HOST_ID_LEN_BYTES);
+		ilm_log_array_dbg("host_id", bswap_host_id,
+		                  IDM_HOST_ID_LEN_BYTES);
+		#else
+		printf("bswap_lock_id    = '");
+		_print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
+		printf("data resource_id = '");
+		_print_char_arr(data_idm[i].resource_id,
+		                IDM_LOCK_ID_LEN_BYTES);
+		printf("bswap_host_id = '");
+		_print_char_arr(bswap_host_id, IDM_HOST_ID_LEN_BYTES);
+		printf("data host_id  = '");
+		_print_char_arr(data_idm[i].host_id, IDM_HOST_ID_LEN_BYTES);
+		#endif //COMPILE_STANDALONE
 
-        #ifndef COMPILE_STANDALONE
-        ilm_log_array_dbg("resource_id",  data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        ilm_log_array_dbg("lock_id",      bswap_lock_id,           IDM_LOCK_ID_LEN_BYTES);
-        ilm_log_array_dbg("data host_id", data_idm[i].host_id,     IDM_HOST_ID_LEN_BYTES);
-        ilm_log_array_dbg("host_id",      bswap_host_id,           IDM_HOST_ID_LEN_BYTES);
-        #else
-        printf("bswap_lock_id    = '");
-        _print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
-        printf("data resource_id = '");
-        _print_char_arr(data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        printf("bswap_host_id = '");
-        _print_char_arr(bswap_host_id, IDM_HOST_ID_LEN_BYTES);
-        printf("data host_id  = '");
-        _print_char_arr(data_idm[i].host_id, IDM_HOST_ID_LEN_BYTES);
-        #endif //COMPILE_STANDALONE
+		/* Skip for other locks */
+		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
+		           IDM_LOCK_ID_LEN_BYTES))
+			continue;
 
-        /* Skip for other locks */
-        if (memcmp(data_idm[i].resource_id, bswap_lock_id, IDM_LOCK_ID_LEN_BYTES))
-            continue;
-
-        if (memcmp(data_idm[i].host_id, bswap_host_id, IDM_HOST_ID_LEN_BYTES)) {
-            /* Must be wrong if self has been accounted */
-            if (*self) {
-                #ifndef COMPILE_STANDALONE
-                ilm_log_err("%s: account self %d > 1", __func__, *self);
-                #else
-                printf("%s: account self %d > 1\n", __func__, *self);
-                #endif //COMPILE_STANDALONE
-                goto EXIT;
-            }
-            *self = 1;
-        }
-        else {
-            *count += 1;
-        }
-    }
+		if (memcmp(data_idm[i].host_id, bswap_host_id,
+		           IDM_HOST_ID_LEN_BYTES)) {
+		/* Must be wrong if self has been accounted */
+			if (*self) {
+				#ifndef COMPILE_STANDALONE
+				ilm_log_err("%s: account self %d > 1",
+					__func__, *self);
+				#else
+				printf("%s: account self %d > 1\n", __func__, *self);
+				#endif //COMPILE_STANDALONE
+				goto EXIT;
+			}
+			*self = 1;
+		}
+		else {
+			*count += 1;
+		}
+	}
 
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
@@ -2282,76 +2388,80 @@ EXIT:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode) {
+int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	idmData        *data_idm;
+	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	int            i;
+	unsigned int   mutex_num = request_idm->data_num;
+	int            ret       = SUCCESS;
+	uint64_t       state, class;
 
-    idmData        *data_idm;
-    char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-    int            i;
-    unsigned int   mutex_num = request_idm->data_num;
-    int            ret       = SUCCESS;
-    uint64_t       state, class;
+	bswap_char_arr(bswap_lock_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
 
-    bswap_char_arr(bswap_lock_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
+	data_idm = request_idm->data_idm;
+	for (i = 0; i < mutex_num; i++) {
 
-    data_idm = request_idm->data_idm;
-    for (i = 0; i < mutex_num; i++) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_array_dbg("resource_id", data_idm[i].resource_id,
+		                  IDM_LOCK_ID_LEN_BYTES);
+		ilm_log_array_dbg("lock_id(bswap)", bswap_lock_id,
+		                  IDM_LOCK_ID_LEN_BYTES);
+		#else
+		printf("lock_id(bswap) = '");
+		_print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
+		printf("resource_id    = '");
+		_print_char_arr(data_idm[i].resource_id,
+		                IDM_LOCK_ID_LEN_BYTES);
+		#endif //COMPILE_STANDALONE
 
-        #ifndef COMPILE_STANDALONE
-        ilm_log_array_dbg("resource_id",   data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        ilm_log_array_dbg("lock_id(bswap)", bswap_lock_id,           IDM_LOCK_ID_LEN_BYTES);
-        #else
-        printf("lock_id(bswap) = '");
-        _print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
-        printf("resource_id    = '");
-        _print_char_arr(data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        #endif //COMPILE_STANDALONE
+		/* Skip for other locks */
+		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
+		           IDM_LOCK_ID_LEN_BYTES))
+			continue;
 
-        /* Skip for other locks */
-        if (memcmp(data_idm[i].resource_id, bswap_lock_id, IDM_LOCK_ID_LEN_BYTES))
-            continue;
+		state = __bswap_64(data_idm[i].state);
+		class = __bswap_64(data_idm[i].class);
 
-        state = __bswap_64(data_idm[i].state);
-        class = __bswap_64(data_idm[i].class);
+		#ifndef COMPILE_STANDALONE
+		ilm_log_dbg("%s: state=%lx class=%lx", __func__, state, class);
+		#else
+		printf("%s: state=%lx class=%lx\n", __func__, state, class);
+		#endif //COMPILE_STANDALONE
 
-        #ifndef COMPILE_STANDALONE
-        ilm_log_dbg("%s: state=%lx class=%lx", __func__, state, class);
-        #else
-        printf("%s: state=%lx class=%lx\n", __func__, state, class);
-        #endif //COMPILE_STANDALONE
+		if (state == IDM_STATE_UNINIT ||
+		    state == IDM_STATE_UNLOCKED ||
+		    state == IDM_STATE_TIMEOUT) {
+			*mode = IDM_MODE_UNLOCK;
+		} else if (class == IDM_CLASS_EXCLUSIVE) {
+			*mode = IDM_MODE_EXCLUSIVE;
+		} else if (class == IDM_CLASS_SHARED_PROTECTED_READ) {
+			*mode = IDM_MODE_SHAREABLE;
+		} else if (class == IDM_CLASS_PROTECTED_WRITE) {
+			#ifndef COMPILE_STANDALONE
+			ilm_log_err("%s: PROTECTED_WRITE is not unsupported", __func__);
+			#endif //COMPILE_STANDALONE
+			ret = -EFAULT;
+		}
 
-        if (state == IDM_STATE_UNINIT ||
-            state == IDM_STATE_UNLOCKED ||
-            state == IDM_STATE_TIMEOUT) {
-            *mode = IDM_MODE_UNLOCK;
-        } else if (class == IDM_CLASS_EXCLUSIVE) {
-            *mode = IDM_MODE_EXCLUSIVE;
-        } else if (class == IDM_CLASS_SHARED_PROTECTED_READ) {
-            *mode = IDM_MODE_SHAREABLE;
-        } else if (class == IDM_CLASS_PROTECTED_WRITE) {
-            #ifndef COMPILE_STANDALONE
-            ilm_log_err("%s: PROTECTED_WRITE is not unsupported", __func__);
-            #endif //COMPILE_STANDALONE
-            ret = -EFAULT;
-        }
+		#ifndef COMPILE_STANDALONE
+		ilm_log_dbg("%s: mode=%d", __func__, *mode);
+		#endif //COMPILE_STANDALONE
 
-        #ifndef COMPILE_STANDALONE
-        ilm_log_dbg("%s: mode=%d", __func__, *mode);
-        #endif //COMPILE_STANDALONE
+		if (*mode == IDM_MODE_EXCLUSIVE || *mode == IDM_MODE_SHAREABLE)
+			break;
+	}
 
-        if (*mode == IDM_MODE_EXCLUSIVE || *mode == IDM_MODE_SHAREABLE)
-            break;
-    }
+	//If the mutex is not found in drive fimware,
+	// simply return success and mode is unlocked.
+	if (*mode == -1)
+		*mode = IDM_MODE_UNLOCK;
 
-    //If the mutex is not found in drive fimware,
-    // simply return success and mode is unlocked.
-    if (*mode == -1)
-        *mode = IDM_MODE_UNLOCK;
-
-    return ret;
+	return ret;
 }
 
 /**
@@ -2366,43 +2476,47 @@ int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode) {
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size) {
+int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	idmData        *data_idm;
+	char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
+	char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
+	int            i;
+	unsigned int   mutex_num = request_idm->data_num;
+	int            ret       = SUCCESS;
 
-    idmData        *data_idm;
-    char           bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
-    char           bswap_host_id[IDM_HOST_ID_LEN_BYTES];
-    int            i;
-    unsigned int   mutex_num = request_idm->data_num;
-    int            ret       = SUCCESS;
+	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
+	               IDM_LOCK_ID_LEN_BYTES);
+	bswap_char_arr(bswap_host_id, request_idm->host_id,
+	               IDM_HOST_ID_LEN_BYTES);
 
-    bswap_char_arr(bswap_lock_id, request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
-    bswap_char_arr(bswap_host_id, request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
+	ret = -ENOENT;
+	data_idm = request_idm->data_idm;
+	for (i = 0; i < mutex_num; i++) {
+		/* Skip for other locks */
+		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
+		           IDM_LOCK_ID_LEN_BYTES))
+			continue;
 
-    ret = -ENOENT;
-    data_idm = request_idm->data_idm;
-    for (i = 0; i < mutex_num; i++) {
-        /* Skip for other locks */
-        if (memcmp(data_idm[i].resource_id, bswap_lock_id, IDM_LOCK_ID_LEN_BYTES))
-            continue;
+		if (memcmp(data_idm[i].host_id, bswap_host_id,
+		           IDM_HOST_ID_LEN_BYTES))
+			continue;
 
-        if (memcmp(data_idm[i].host_id, bswap_host_id, IDM_HOST_ID_LEN_BYTES))
-            continue;
+		bswap_char_arr(lvb, data_idm[i].resource_ver, lvb_size);
+		ret = SUCCESS;
+		break;
+	}
 
-        bswap_char_arr(lvb, data_idm[i].resource_ver, lvb_size);
-        ret = SUCCESS;
-        break;
-    }
-
-    return ret;
+	return ret;
 }
 
 /**
- * _parse_mutex_group - Convenience function for parsing struct idm_info data out of the
- * returned data payload.
+ * _parse_mutex_group - Convenience function for parsing struct idm_info data
+ * out of the returned data payload.
  *
  * @request_idm: Struct containing all NVMe-specific command info for the
  *               requested IDM action.
@@ -2413,112 +2527,117 @@ int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size) {
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _parse_mutex_group(nvmeIdmRequest *request_idm, struct idm_info **info_ptr, int *info_num) {
+int _parse_mutex_group(nvmeIdmRequest *request_idm, struct idm_info **info_ptr,
+                       int *info_num)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	idmData        *data_idm;
+	unsigned int   mutex_num = request_idm->data_num;
+	int            i, ret    = SUCCESS;
+	uint64_t       state, class;
+	struct idm_info        *info_list, *info;
 
-    idmData        *data_idm;
-    unsigned int   mutex_num = request_idm->data_num;
-    int            i, ret    = SUCCESS;
-    uint64_t       state, class;
-    struct idm_info        *info_list, *info;
+	info_list = malloc(sizeof(struct idm_info) * mutex_num);
+	if (!info_list) {
+		ret = -ENOMEM;
+		goto EXIT;
+	}
 
-    info_list = malloc(sizeof(struct idm_info) * mutex_num);
-    if (!info_list) {
-        ret = -ENOMEM;
-        goto EXIT;
-    }
+	//Find info
+	data_idm = request_idm->data_idm;
+	for (i = 0; i < mutex_num; i++) {
 
-    //Find info
-    data_idm = request_idm->data_idm;
-    for (i = 0; i < mutex_num; i++) {
+		state = __bswap_64(data_idm[i].state);
+		if (state == IDM_STATE_DEAD)
+		break;
 
-        state = __bswap_64(data_idm[i].state);
-        if (state == IDM_STATE_DEAD)
-            break;
+		info = info_list + i;
 
-        info = info_list + i;
+		/* Copy host ID */
+		bswap_char_arr(info->id, data_idm[i].resource_id,
+		               IDM_LOCK_ID_LEN_BYTES);
+		bswap_char_arr(info->host_id, data_idm[i].host_id,
+		               IDM_HOST_ID_LEN_BYTES);
 
-        /* Copy host ID */
-        bswap_char_arr(info->id,      data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
-        bswap_char_arr(info->host_id, data_idm[i].host_id,     IDM_HOST_ID_LEN_BYTES);
+		class = __bswap_64(data_idm[i].class);
 
-        class = __bswap_64(data_idm[i].class);
+		switch (class) {
+		case IDM_CLASS_EXCLUSIVE:
+			info->mode = IDM_MODE_EXCLUSIVE;
+			break;
+		case IDM_CLASS_SHARED_PROTECTED_READ:
+			info->mode = IDM_MODE_SHAREABLE;
+			break;
+		default:
+			#ifndef COMPILE_STANDALONE
+			ilm_log_err("%s: IDM class is not unsupported %ld",
+			            __func__, class);
+			#endif //COMPILE_STANDALONE
+			ret = -EFAULT;
+			goto EXIT;
+		}
 
-        switch (class) {
-            case IDM_CLASS_EXCLUSIVE:
-                info->mode = IDM_MODE_EXCLUSIVE;
-                break;
-            case IDM_CLASS_SHARED_PROTECTED_READ:
-                info->mode = IDM_MODE_SHAREABLE;
-                break;
-            default:
-                #ifndef COMPILE_STANDALONE
-                ilm_log_err("%s: IDM class is not unsupported %ld", __func__, class);
-                #endif //COMPILE_STANDALONE
-                ret = -EFAULT;
-                goto EXIT;
-        }
+		switch (state) {
+		case IDM_STATE_UNINIT:
+			info->state = -1;   //TODO: hardcoded state. what is this? add to enum?
+			break;
+		case IDM_STATE_UNLOCKED: //intended fall-through
+		case IDM_STATE_TIMEOUT:
+			info->state = IDM_MODE_UNLOCK;
+			break;
+		default:
+			info->state = 1;    //TODO: hardcoded state. what is this? add to enum?
+		}
 
-        switch (state) {
-            case IDM_STATE_UNINIT:
-                info->state = -1;   //TODO: hardcoded state. what is this? add to enum?
-                break;
-            case IDM_STATE_UNLOCKED: //intended fall-through
-            case IDM_STATE_TIMEOUT:
-                info->state = IDM_MODE_UNLOCK;
-                break;
-            default:
-                info->state = 1;    //TODO: hardcoded state. what is this? add to enum?
-        }
+		info->last_renew_time = __bswap_64(data_idm[i].time_now);
+	}
 
-        info->last_renew_time = __bswap_64(data_idm[i].time_now);
-    }
-
-    *info_ptr = info_list;
-    *info_num = i;
+	*info_ptr = info_list;
+	*info_num = i;
 
 EXIT:
-    if (ret != 0 && info_list)
-        free(info_list);
-    return ret;
+	if (ret != 0 && info_list)
+		free(info_list);
+	return ret;
 }
 
 /**
- * _parse_mutex_num - Convenience function for parsing the number of mutexes out of the
- * returned data payload.
+ * _parse_mutex_num - Convenience function for parsing the number of mutexes
+ * out of the returned data payload.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  * @mutex_num:      Returned number of mutexes present on the drive.
  */
-void _parse_mutex_num(nvmeIdmRequest *request_idm, unsigned int *mutex_num) {
+void _parse_mutex_num(nvmeIdmRequest *request_idm, unsigned int *mutex_num)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
-
-    unsigned char  *data;
+	unsigned char  *data;
 
 //TODO: Ported from scsi-side as-is.  Need to verify if this even makes sense for nvme.
 //TODO: Why is "unsigned char" being used here??
-    data = (unsigned char *)request_idm->data_idm;
-    #ifdef FORCE_MUTEX_NUM
+	data = (unsigned char *)request_idm->data_idm;
+	#ifdef FORCE_MUTEX_NUM
 //TODO: This can't stay. Necessary for stand-alone code
-    *mutex_num = 1;     //For debug. This func called by many others.
-    #else
-    *mutex_num = ((data[1]) & 0xff);
-    *mutex_num |= ((data[0]) & 0xff) << 8;
-    #endif //FORCE_MUTEX_NUM
+	*mutex_num = 1;     //For debug. This func called by many others.
+	#else
+	*mutex_num = ((data[1]) & 0xff);
+	*mutex_num |= ((data[0]) & 0xff) << 8;
+	#endif //FORCE_MUTEX_NUM
 
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: data[0]=%u data[1]=%u mutex mutex_num=%u",
-                __func__, data[0], data[1], *mutex_num);
-    #else
-    printf("%s: data[0]=%u data[1]=%u mutex mutex_num=%u\n",
-           __func__, data[0], data[1], *mutex_num);
-    #endif //COMPILE_STANDALONE
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: data[0]=%u data[1]=%u mutex mutex_num=%u",
+	            __func__, data[0], data[1], *mutex_num);
+	#else
+	printf("%s: data[0]=%u data[1]=%u mutex mutex_num=%u\n",
+	       __func__, data[0], data[1], *mutex_num);
+	#endif //COMPILE_STANDALONE
 }
 
 /**
@@ -2531,28 +2650,28 @@ void _parse_mutex_num(nvmeIdmRequest *request_idm, unsigned int *mutex_num) {
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _validate_input_common(char *lock_id, char *host_id, char *drive) {
+int _validate_input_common(char *lock_id, char *host_id, char *drive)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	#ifndef COMPILE_STANDALONE
+	if (ilm_inject_fault_is_hit())
+		return -EIO;
+	#endif //COMPILE_STANDALONE
 
-    #ifndef COMPILE_STANDALONE
-    if (ilm_inject_fault_is_hit())
-        return -EIO;
-    #endif //COMPILE_STANDALONE
+	if (!lock_id || !host_id || !drive)
+		return -EINVAL;
 
-    if (!lock_id || !host_id || !drive)
-        return -EINVAL;
-
-    return ret;
+	return ret;
 }
 
 /**
- * _validate_input_write - Convenience function for validating IDM API input parameters
- * used during an IDM write cmd.
+ * _validate_input_write - Convenience function for validating IDM API input
+ * parameters used during an IDM write cmd.
  *
  * @lock_id:        Lock ID (64 bytes).
  * @mode:           Lock mode (unlock, shareable, exclusive).
@@ -2561,20 +2680,20 @@ int _validate_input_common(char *lock_id, char *host_id, char *drive) {
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive) {
+int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _validate_input_common(lock_id, host_id, drive);
 
-    ret = _validate_input_common(lock_id, host_id, drive);
+	if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
+		return -EINVAL;
 
-    if (mode != IDM_MODE_EXCLUSIVE && mode != IDM_MODE_SHAREABLE)
-        return -EINVAL;
-
-    return ret;
+	return ret;
 }
 
 

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -499,7 +499,8 @@ EXIT:
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
-                                char *drive, uint64_t timeout, uint64_t *handle)
+                                char *drive, uint64_t timeout,
+                                uint64_t *handle)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -19,27 +19,35 @@
 
 void nvme_idm_async_free_result(uint64_t handle);
 int nvme_idm_async_get_result(uint64_t handle, int *result);
-int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count, int *self, int *result);
-int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode, int *result);
-int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size, int *result);
+int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count,
+                                         int *self, int *result);
+int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode,
+                                        int *result);
+int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size,
+                                  int *result);
 
 int nvme_idm_async_lock(char *lock_id, int mode, char *host_id,
                         char *drive, uint64_t timeout, uint64_t *handle);
 int nvme_idm_async_lock_break(char *lock_id, int mode, char *host_id,
                               char *drive, uint64_t timeout, uint64_t *handle);
 int nvme_idm_async_lock_convert(char *lock_id, int mode, char *host_id,
-                                char *drive, uint64_t timeout, uint64_t *handle);
+                                char *drive, uint64_t timeout,
+                                uint64_t *handle);
 int nvme_idm_async_lock_destroy(char *lock_id, int mode, char *host_id,
                                 char *drive, uint64_t *handle);
 int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
-                                char *drive, uint64_t timeout, uint64_t *handle);
+                                char *drive, uint64_t timeout,
+                                uint64_t *handle);
 int nvme_idm_async_lock_renew(char *lock_id, int mode, char *host_id,
                               char *drive, uint64_t timeout, uint64_t *handle);
-int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive, uint64_t *handle);
+int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive,
+                                   uint64_t *handle);
 int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle);
-int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive, uint64_t *handle);
+int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive,
+                            uint64_t *handle);
 int nvme_idm_async_unlock(char *lock_id, int mode, char *host_id,
-                          char *lvb, int lvb_size, char *drive, uint64_t *handle);
+                          char *lvb, int lvb_size, char *drive,
+                          uint64_t *handle);
 
 int nvme_idm_get_fd(uint64_t handle);
 int nvme_idm_read_version(int *version, char *drive);
@@ -56,12 +64,15 @@ int nvme_idm_sync_lock_refresh(char *lock_id, int mode, char *host_id,
                                char *drive, uint64_t timeout);
 int nvme_idm_sync_lock_renew(char *lock_id, int mode, char *host_id,
                              char *drive, uint64_t timeout);
-int nvme_idm_sync_read_host_state(char *lock_id, char *host_id, int *host_state, char *drive);
-int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count, int *self,
-                                  char *drive);
+int nvme_idm_sync_read_host_state(char *lock_id, char *host_id,
+                                  int *host_state, char *drive);
+int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
+                                  int *self, char *drive);
 int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive);
-int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb, int lvb_size, char *drive);
-int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr, int *info_num);
+int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
+                           int lvb_size, char *drive);
+int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
+                                   int *info_num);
 int nvme_idm_sync_read_mutex_num(char *drive, unsigned int *mutex_num);
 int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
                          char *lvb, int lvb_size, char *drive);
@@ -76,25 +87,27 @@ int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
                        uint64_t timeout, nvmeIdmRequest **request_idm);
 int _init_read_host_state(char *lock_id, char *host_id, char *drive,
                           nvmeIdmRequest **request_idm);
-int _init_read_lock_count(int async_on, char *lock_id, char *host_id, char *drive,
-                          nvmeIdmRequest **request_idm);
+int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
+                          char *drive, nvmeIdmRequest **request_idm);
 int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
                          nvmeIdmRequest **request_idm);
 int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
                    nvmeIdmRequest **request_idm);
 int _init_read_mutex_group(char *drive, nvmeIdmRequest **request_idm);
 int _init_read_mutex_num(char *drive, nvmeIdmRequest **request_idm);
-int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb, int lvb_size,
-                 char *drive, nvmeIdmRequest **request_idm);
+int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
+                 int lvb_size, char *drive, nvmeIdmRequest **request_idm);
 
 void _memory_free_idm_request(nvmeIdmRequest *request_idm);
-int _memory_init_idm_request(nvmeIdmRequest **request_idm, unsigned int data_num);
+int _memory_init_idm_request(nvmeIdmRequest **request_idm,
+                             unsigned int data_num);
 
 int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state);
 int _parse_lock_count(nvmeIdmRequest *request_idm, int *count, int *self);
 int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode);
 int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size);
-int _parse_mutex_group(nvmeIdmRequest *request_idm, struct idm_info **info_ptr, int *info_num);
+int _parse_mutex_group(nvmeIdmRequest *request_idm, struct idm_info **info_ptr,
+                       int *info_num);
 void _parse_mutex_num(nvmeIdmRequest *request_idm, unsigned int *mutex_num);
 
 int _validate_input_common(char *lock_id, char *host_id, char *drive);

--- a/src/idm_nvme_api.h
+++ b/src/idm_nvme_api.h
@@ -78,37 +78,40 @@ int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
                          char *lvb, int lvb_size, char *drive);
 
 int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
-               uint64_t timeout, nvmeIdmRequest **request_idm);
+               uint64_t timeout, struct idm_nvme_request **request_idm);
 int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
-                     uint64_t timeout, nvmeIdmRequest **request_idm);
+                     uint64_t timeout, struct idm_nvme_request **request_idm);
 int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
-                       nvmeIdmRequest **request_idm);
+                       struct idm_nvme_request **request_idm);
 int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
-                       uint64_t timeout, nvmeIdmRequest **request_idm);
+                       uint64_t timeout, struct idm_nvme_request **request_idm);
 int _init_read_host_state(char *lock_id, char *host_id, char *drive,
-                          nvmeIdmRequest **request_idm);
+                          struct idm_nvme_request **request_idm);
 int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
-                          char *drive, nvmeIdmRequest **request_idm);
+                          char *drive, struct idm_nvme_request **request_idm);
 int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
-                         nvmeIdmRequest **request_idm);
+                         struct idm_nvme_request **request_idm);
 int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
-                   nvmeIdmRequest **request_idm);
-int _init_read_mutex_group(char *drive, nvmeIdmRequest **request_idm);
-int _init_read_mutex_num(char *drive, nvmeIdmRequest **request_idm);
+                   struct idm_nvme_request **request_idm);
+int _init_read_mutex_group(char *drive, struct idm_nvme_request **request_idm);
+int _init_read_mutex_num(char *drive, struct idm_nvme_request **request_idm);
 int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
-                 int lvb_size, char *drive, nvmeIdmRequest **request_idm);
+                 int lvb_size, char *drive,
+                 struct idm_nvme_request **request_idm);
 
-void _memory_free_idm_request(nvmeIdmRequest *request_idm);
-int _memory_init_idm_request(nvmeIdmRequest **request_idm,
+void _memory_free_idm_request(struct idm_nvme_request *request_idm);
+int _memory_init_idm_request(struct idm_nvme_request **request_idm,
                              unsigned int data_num);
 
-int _parse_host_state(nvmeIdmRequest *request_idm, int *host_state);
-int _parse_lock_count(nvmeIdmRequest *request_idm, int *count, int *self);
-int _parse_lock_mode(nvmeIdmRequest *request_idm, int *mode);
-int _parse_lvb(nvmeIdmRequest *request_idm, char *lvb, int lvb_size);
-int _parse_mutex_group(nvmeIdmRequest *request_idm, struct idm_info **info_ptr,
-                       int *info_num);
-void _parse_mutex_num(nvmeIdmRequest *request_idm, unsigned int *mutex_num);
+int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state);
+int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
+                      int *self);
+int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode);
+int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size);
+int _parse_mutex_group(struct idm_nvme_request *request_idm,
+                       struct idm_info **info_ptr, int *info_num);
+void _parse_mutex_num(struct idm_nvme_request *request_idm,
+                      unsigned int *mutex_num);
 
 int _validate_input_common(char *lock_id, char *host_id, char *drive);
 int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive);

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -62,133 +62,146 @@
 //////////////////////////////////////////
 
 /**
- * nvme_idm_async_data_rcv - Asynchronously retrieves the status word and (as needed) data from
- * a specified device for a previously issued NVMe IDM command.
+ * nvme_idm_async_data_rcv - Asynchronously retrieves the status word and
+ * (as needed) data from a specified device for a previously issued NVMe
+ * IDM command.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for
+ *                  the requested IDM action.
  * @result:         Returned result for the operation.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_data_rcv(nvmeIdmRequest *request_idm, int *result) {
+int nvme_idm_async_data_rcv(nvmeIdmRequest *request_idm, int *result)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _async_idm_data_rcv(request_idm, result);
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: _async_idm_data_rcv fail %d", __func__, ret);
+		#else
+		printf("%s: _async_idm_data_rcv fail %d\n", __func__, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
-    ret = _async_idm_data_rcv(request_idm, result);
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: _async_idm_data_rcv fail %d", __func__, ret);
-        #else
-        printf("%s: _async_idm_data_rcv fail %d\n", __func__, ret);
-        #endif //COMPILE_STANDALONE
-    }
-
-    close(request_idm->fd_nvme);
-    return ret;
+	close(request_idm->fd_nvme);
+	return ret;
 }
 
 /**
- * nvme_idm_async_read - Issues a custom (vendor-specific) NVMe command to the drive that then
- * executes a READ action on the IDM.  The specific action performed on the IDM is defined
- * by the IDM opcode set within the NVMe command structure.
- * However, this function issues this NVMe command asychronously.  Therefore, a separate
- * async command must be called to determine the success\failure of the specified IDM opcode.
+ * nvme_idm_async_read - Issues a custom (vendor-specific) NVMe command to
+ * the drive that then executes a READ action on the IDM.  The specific
+ * action performed on the IDM is defined by the IDM opcode set within the
+ * NVMe command structure.
+ * However, this function issues this NVMe command asychronously.  Therefore,
+ * a separate async command must be called to determine the success\failure
+ * of the specified IDM opcode.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_read(nvmeIdmRequest *request_idm) {
+int nvme_idm_async_read(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
-    if (ret < 0) {
-        return ret;
-    }
+	// ret = _idm_data_init_rd(request_idm);   TODO: Needed?
+	// if (ret < 0) {
+	// 	return ret;
+	// }
 
-    // ret = _idm_data_init_rd(request_idm);   TODO: Needed?
-    // if (ret < 0) {
-    //     return ret;
-    // }
+	ret = _async_idm_cmd_send(request_idm);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _async_idm_cmd_send(request_idm);
-    if (ret < 0) {
-        return ret;
-    }
-
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_async_write - Issues a custom (vendor-specific) NVMe command to the drive that then
- * executes a WRITE action on the IDM.  The specific action performed on the IDM is defined
- * by the IDM opcode set within the NVMe command structure.
- * However, this function issues this NVMe command asychronously.  Therefore, a separate
- * async command must be called to determine the success\failure of the specified IDM opcode.
+ * nvme_idm_async_write - Issues a custom (vendor-specific) NVMe command to
+ * the drive that then executes a WRITE action on the IDM.  The specific
+ * action performed on the IDM is defined by the IDM opcode set within the
+ * NVMe command structure.
+ * However, this function issues this NVMe command asychronously.  Therefore,
+ * a separate async command must be called to determine the success\failure
+ * of the specified IDM opcode.
  * Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
  * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_write(nvmeIdmRequest *request_idm) {
+int nvme_idm_async_write(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
-    if (ret < 0) {
-        return ret;
-    }
+	ret = _idm_data_init_wrt(request_idm);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _idm_data_init_wrt(request_idm);
-    if (ret < 0) {
-        return ret;
-    }
+	ret = _async_idm_cmd_send(request_idm);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _async_idm_cmd_send(request_idm);
-    if (ret < 0) {
-        return ret;
-    }
-
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_read_init - Initializes an NVMe READ to the IDM by validating and then collecting
- * all the IDM API input params and storing them in the "request_idm" data struct for use later
- * (but before the NVMe write command is sent to the OS kernel).
+ * nvme_idm_read_init - Initializes an NVMe READ to the IDM by validating
+ * and then collecting all the IDM API input params and storing them in the
+ * "request_idm" data struct for use later (but before the NVMe write command
+ * is sent to the OS kernel).
  * Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
  * @drive:          Drive path name.
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  */
-void nvme_idm_read_init(char *drive, nvmeIdmRequest *request_idm) {
+void nvme_idm_read_init(char *drive, nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	request_idm->opcode_idm = IDM_OPCODE_INIT;  //Ignored, but default for all idm reads.
+	strncpy(request_idm->drive, drive, PATH_MAX);
+//TODO: Do I need a non-zero default timeout here for NVMe reads???
+//	request_idm->timeout  = 100;
 
-    request_idm->opcode_idm = IDM_OPCODE_INIT;  //Ignored, but default for all idm reads.
-    strncpy(request_idm->drive, drive, PATH_MAX);
 }
 
 /**
- * nvme_idm_write_init - Initializes an NVMe WRITE to the IDM by validating and then collecting
- * all the IDM API input params and storing them in the "request_idm" data struct for use later
- * (but before the NVMe write command is sent to the OS kernel).
+ * nvme_idm_write_init - Initializes an NVMe WRITE to the IDM by validating
+ * and then collecting all the IDM API input params and storing them in the
+ * "request_idm" data struct for use later (but before the NVMe write command
+ * is sent to the OS kernel).
  * Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
  * @lock_id:        Lock ID (64 bytes).
@@ -196,574 +209,604 @@ void nvme_idm_read_init(char *drive, nvmeIdmRequest *request_idm) {
  * @host_id:        Host ID (32 bytes).
  * @drive:          Drive path name.
  * @timeout:        Timeout for membership (unit: millisecond).
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
-                        uint64_t timeout, nvmeIdmRequest *request_idm) {
+                        uint64_t timeout, nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
-
-    //Cache the input params
+	//Cache the input params
 //TODO: memcpy() -OR- strncpy() HERE?? (and everywhere else for that matter)
-    memcpy(request_idm->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
-    memcpy(request_idm->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
-    memcpy(request_idm->drive  , drive  , PATH_MAX);
-    request_idm->mode_idm = mode;
-    request_idm->timeout  = timeout;
+	memcpy(request_idm->lock_id, lock_id, IDM_LOCK_ID_LEN_BYTES);
+	memcpy(request_idm->host_id, host_id, IDM_HOST_ID_LEN_BYTES);
+	memcpy(request_idm->drive  , drive  , PATH_MAX);
+	request_idm->mode_idm = mode;
+	request_idm->timeout  = timeout;
 
+	//Currently fixed for NVME writes
 //TODO: This is variable for NVMe reads.  How handle?  MAY be variable for writes too (future).
-    request_idm->group_idm = IDM_GROUP_DEFAULT;   //Currently fixed for NVME writes
+	request_idm->group_idm = IDM_GROUP_DEFAULT;
 
-    switch(mode) {
-        case IDM_MODE_EXCLUSIVE:
-            request_idm->class = IDM_CLASS_EXCLUSIVE;
-            break;
-        case IDM_MODE_SHAREABLE:
-            request_idm->class = IDM_CLASS_SHARED_PROTECTED_READ;
-            break;
-        default:
-            //Other modes not supported at this time
-            return -EINVAL;
-    }
+	switch(mode) {
+		case IDM_MODE_EXCLUSIVE:
+			request_idm->class = IDM_CLASS_EXCLUSIVE;
+			break;
+		case IDM_MODE_SHAREABLE:
+			request_idm->class = IDM_CLASS_SHARED_PROTECTED_READ;
+			break;
+		default:
+			//Other modes not supported at this time
+			return -EINVAL;
+	}
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 /**
- * nvme_idm_sync_read - Issues a custom (vendor-specific) NVMe command to the drive that then
- * executes a READ action on the IDM.  The specific action performed on the IDM is defined
- * by the IDM opcode set within the NVMe command structure.
+ * nvme_idm_sync_read - Issues a custom (vendor-specific) NVMe command to
+ * the drive that then executes a READ action on the IDM.  The specific action
+ * performed on the IDM is defined by the IDM opcode set within the NVMe
+ * command structure.
  * Intended to be called by higher level read IDM API's.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_read(nvmeIdmRequest *request_idm) {
+int nvme_idm_sync_read(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_READ);
-    if (ret < 0) {
-        return ret;
-    }
+	// ret = _idm_data_init_rd(request_idm);   TODO: Needed?
+	// if (ret < 0) {
+	// 	return ret;
+	// }
 
-    // ret = _idm_data_init_rd(request_idm);   TODO: Needed?
-    // if (ret < 0) {
-    //     return ret;
-    // }
-
-    ret = _sync_idm_cmd_send(request_idm);
-    if (ret < 0) {
-        return ret;
-    }
+	ret = _sync_idm_cmd_send(request_idm);
+	if (ret < 0) {
+		return ret;
+	}
 
 //TODO: Put on debug flag OR remove??
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: retrieved idmData", __func__);
-    #else
-    printf("%s: retrieved idmData\n", __func__);
-    #endif //COMPILE_STANDALONE
-    dumpIdmDataStruct(request_idm->data_idm);
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: retrieved idmData", __func__);
+	#else
+	printf("%s: retrieved idmData\n", __func__);
+	#endif //COMPILE_STANDALONE
+	dumpIdmDataStruct(request_idm->data_idm);
 
-    return ret;
+	return ret;
 }
 
 /**
- * nvme_idm_sync_write - Issues a custom (vendor-specific) NVMe command to the device that then
- * executes a WRITE action on the IDM.  The specific action performed on the IDM is defined
- * by the IDM opcode set within the NVMe command structure.
+ * nvme_idm_sync_write - Issues a custom (vendor-specific) NVMe command to
+ * the device that then executes a WRITE action on the IDM.  The specific action
+ * performed on the IDM is defined by the IDM opcode set within the NVMe
+ * command structure.
  * Intended to be called by higher level IDM API's (i.e.: lock, unlock, etc).
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_write(nvmeIdmRequest *request_idm) {
+int nvme_idm_sync_write(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	int ret = SUCCESS;
 
-    int ret = SUCCESS;
+	ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _idm_cmd_init(request_idm, NVME_IDM_VENDOR_CMD_OP_WRITE);
-    if (ret < 0) {
-        return ret;
-    }
+	ret = _idm_data_init_wrt(request_idm);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _idm_data_init_wrt(request_idm);
-    if (ret < 0) {
-        return ret;
-    }
+	ret = _sync_idm_cmd_send(request_idm);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ret = _sync_idm_cmd_send(request_idm);
-    if (ret < 0) {
-        return ret;
-    }
-
-    return ret;
+	return ret;
 }
 
 /**
- * _async_idm_cmd_send - Forms and then sends an NVMe IDM command to the system device,
- * but does so asynchronously.
- * Does so by transfering data from the "request_idm" struct to the final "nvme_passthru_cmd"
- * struct used by the system.
+ * _async_idm_cmd_send - Forms and then sends an NVMe IDM command to the
+ * system device, but does so asynchronously.
+ * Does so by transfering data from the "request_idm" struct to the final
+ * "nvme_passthru_cmd" struct used by the system.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _async_idm_cmd_send(nvmeIdmRequest *request_idm) {
+int _async_idm_cmd_send(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	struct nvme_passthru_cmd cmd_nvme_passthru;
+	int fd_nvme;
+	int ret = SUCCESS;
 
-    struct nvme_passthru_cmd cmd_nvme_passthru;
-    int fd_nvme;
-    int ret = SUCCESS;
+	//TODO: Put this under a debug flag of some kind??
+	dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
+	dumpIdmDataStruct(request_idm->data_idm);
 
-    //TODO: Put this under a debug flag of some kind??
-    dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
-    dumpIdmDataStruct(request_idm->data_idm);
+	memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
-    memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
+	fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
+	if (fd_nvme < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: error opening drive %s fd %d",
+		            __func__, request_idm->drive, fd_nvme);
+		#else
+		printf("%s: error opening drive %s fd %d\n",
+		       __func__, request_idm->drive, fd_nvme);
+		#endif //COMPILE_STANDALONE
+		return fd_nvme;
+	}
 
-    fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
-    if (fd_nvme < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: error opening drive %s fd %d", __func__, request_idm->drive, fd_nvme);
-        #else
-        printf("%s: error opening drive %s fd %d\n", __func__, request_idm->drive, fd_nvme);
-        #endif //COMPILE_STANDALONE
-        return fd_nvme;
-    }
+	_fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
 
-    _fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
+	//TODO: Keep?  Add debug flag?
+	dumpNvmePassthruCmd(&cmd_nvme_passthru);
 
-    //TODO: Keep?  Add debug flag?
-    dumpNvmePassthruCmd(&cmd_nvme_passthru);
-
-    //TODO: Don't know exactly how to do this async communication yet via NVMe.
-    //      This write() call is just a duplication of what scsi is doing
-    printf("%s: CORE NVME ASYNC WRITE IO NOT YET FUNCTIONAL!\n", __func__);
-    // ret = write(fd_nvme, &cmd_nvme_passthru, sizeof(cmd_nvme_passthru));
-    if (ret) {
-        close(fd_nvme);
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: write failed: %d(0x%X)", __func__, ret, ret);
-        #else
-        printf("%s: write failed: %d(0x%X)\n", __func__, ret, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
+	//TODO: Don't know exactly how to do this async communication yet via NVMe.
+	//      This write() call is just a duplication of what scsi is doing
+	printf("%s: CORE NVME ASYNC WRITE IO NOT YET FUNCTIONAL!\n", __func__);
+	// ret = write(fd_nvme, &cmd_nvme_passthru, sizeof(cmd_nvme_passthru));
+	if (ret) {
+		close(fd_nvme);
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: write failed: %d(0x%X)", __func__, ret, ret);
+		#else
+		printf("%s: write failed: %d(0x%X)\n", __func__, ret, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
 EXIT:
-    request_idm->fd_nvme = fd_nvme;  //async, so save fd_nvme for later
-    return ret;
+	request_idm->fd_nvme = fd_nvme;  //async, so save fd_nvme for later
+	return ret;
 }
 
 /**
- * _async_idm_data_rcv - Asynchronously retrieves the status word and (as needed) data from
- * a specified device for a previously issued NVMe IDM command.
+ * _async_idm_data_rcv - Asynchronously retrieves the status word and
+ * (as needed) data from a specified device for a previously issued NVMe
+ * IDM command.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  * @result:         Returned result for the operation.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _async_idm_data_rcv(nvmeIdmRequest *request_idm, int *result) {
+int _async_idm_data_rcv(nvmeIdmRequest *request_idm, int *result)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	struct nvme_passthru_cmd cmd_nvme_passthru;
+	int status_async_cmd;    //The status of the PREVIOUSLY issued async cmd
+	int ret = SUCCESS;
 
-    struct nvme_passthru_cmd cmd_nvme_passthru;
-    int status_async_cmd;    //The status of the PREVIOUSLY issued async cmd
-    int ret = SUCCESS;
+	//TODO: Put this under a debug flag of some kind??
+	dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
+	dumpIdmDataStruct(request_idm->data_idm);
 
-    //TODO: Put this under a debug flag of some kind??
-    dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
-    dumpIdmDataStruct(request_idm->data_idm);
+	memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
-    memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
+	if (!request_idm->fd_nvme) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: invalid device handle", __func__);
+		#else
+		printf("%s: invalid device handle\n", __func__);
+		#endif //COMPILE_STANDALONE
+		ret = FAILURE;
+		goto EXIT;
+	}
 
-    if (!request_idm->fd_nvme) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: invalid device handle", __func__);
-        #else
-        printf("%s: invalid device handle\n", __func__);
-        #endif //COMPILE_STANDALONE
-        ret = FAILURE;
-        goto EXIT;
-    }
+	//TODO: If emulate what SCSI-side is doing, this fill is NOT necessary.
+	//          ?? Does ONLY the opcode_nvme needs to be updated (to indicate the concept of "direction" (like SCSI-side))?????
+	// _fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
 
-    //TODO: If emulate what SCSI-side is doing, this fill is NOT necessary.
-    //          ?? Does ONLY the opcode_nvme needs to be updated (to indicate the concept of "direction" (like SCSI-side))?????
-    // _fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
+	//Simplified command for result\data retrieval
+	//TODO: (SCSI-side equivalent).  Does NVMe follow this??
+	//TODO: This is wrong.
+	//       Hardcode the opcode_nvme OR pass it in (if it could be a 0xC1 or 0xC2)????
+	cmd_nvme_passthru.opcode       = request_idm->cmd_nvme.opcode_nvme;
 
-    //Simplified command for result\data retrieval
-    //TODO: (SCSI-side equivalent).  Does NVMe follow this??
-    //TODO: This is wrong.
-    //       Hardcode the opcode_nvme OR pass it in (if it could be a 0xC1 or 0xC2)????
-    cmd_nvme_passthru.opcode       = request_idm->cmd_nvme.opcode_nvme;
+	//TODO: Keep?  Add debug flag?
+	dumpNvmePassthruCmd(&cmd_nvme_passthru);
 
-    //TODO: Keep?  Add debug flag?
-    dumpNvmePassthruCmd(&cmd_nvme_passthru);
+	//TODO: Don't know exactly how to do this async communication yet via NVMe.
+	//      This read() call is just a duplication of what scsi is doing
+	printf("%s: CORE NVME ASYNC READ IO NOT YET FUNCTIONAL!\n", __func__);
+	// ret = read(request_idm->fd_nvme, &cmd_nvme_passthru, sizeof(cmd_nvme_passthru));
+	if (ret < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: read failed: %d(0x%X)", __func__, ret, ret);
+		#else
+		printf("%s: read failed: %d(0x%X)\n", __func__, ret, ret);
+		#endif //COMPILE_STANDALONE
+		goto EXIT;
+	}
 
-    //TODO: Don't know exactly how to do this async communication yet via NVMe.
-    //      This read() call is just a duplication of what scsi is doing
-    printf("%s: CORE NVME ASYNC READ IO NOT YET FUNCTIONAL!\n", __func__);
-    // ret = read(request_idm->fd_nvme, &cmd_nvme_passthru, sizeof(cmd_nvme_passthru));
-    if (ret < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: read failed: %d(0x%X)", __func__, ret, ret);
-        #else
-        printf("%s: read failed: %d(0x%X)\n", __func__, ret, ret);
-        #endif //COMPILE_STANDALONE
-        goto EXIT;
-    }
+	//TODO: Review _scsi_read() code for this part here
 
-    //TODO: Review _scsi_read() code for this part here
+	//TODO: Where does "status_async_cmd" come from in NVMe?
+	//              ?? cmd_nvme_passthru.result?
+	//              ?? Somewhere in data_idm (.addr)?
+	//      There is no NVMe equivalent to:
+	//              1.) SCSI's "io_hdr.info & SG_INFO_OK_MASK" check, which determines Pass\Fail of the PREVIOUS async cmd, OR
+	//              2.) SCSI's "io_hdr.masked_status", which, on Fail, is used to determine the final "result" (ie - error\return code) from the PREVIOUS async cmd
+	// status_async_cmd = ?????????????????????????????????????????????????????????????????????????????
 
-    //TODO: Where does "status_async_cmd" come from in NVMe?
-    //              ?? cmd_nvme_passthru.result?
-    //              ?? Somewhere in data_idm (.addr)?
-    //      There is no NVMe equivalent to:
-    //              1.) SCSI's "io_hdr.info & SG_INFO_OK_MASK" check, which determines Pass\Fail of the PREVIOUS async cmd, OR
-    //              2.) SCSI's "io_hdr.masked_status", which, on Fail, is used to determine the final "result" (ie - error\return code) from the PREVIOUS async cmd
-    // status_async_cmd = ?????????????????????????????????????????????????????????????????????????????
+	//TODO: Broken until it's determined how to retrieve the P\F of PREVIOUS async cmd AND where the status code is passed back.
+	status_async_cmd = 0;	//To get rid of compile warning (for now).
+	*result = _idm_cmd_check_status(status_async_cmd,
+	                                request_idm->opcode_idm);
 
-    //TODO: Broken until it's determined how to retrieve the P\F of PREVIOUS async cmd AND where the status code is passed back.
-    *result = _idm_cmd_check_status(status_async_cmd, request_idm->opcode_idm);
-
-    //TODO: Keep this printf()?  Switch to ilm_log_dbg??
-    printf("%s: found previous async result=%d\n", __func__, *result);
+	//TODO: Keep this printf()?  Switch to ilm_log_dbg??
+	printf("%s: found previous async result=%d\n", __func__, *result);
 
 EXIT:
-    return ret;
+	return ret;
 }
 
 /**
- * _fill_nvme_cmd -  Transfer all the data in the "request" structure to the prefined system NVMe
- * command structure used by the system commands (like ioctl()).
+ * _fill_nvme_cmd -  Transfer all the data in the "request" structure to the
+ * prefined system NVMe command structure used by the system commands
+ * (like ioctl()).
  *
- * @request_idm:        Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:        Struct containing all NVMe-specific command info for the
+ *                      requested IDM action.
  * @cmd_nvme_passthru:  Predefined NVMe command struct to be filled.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-void _fill_nvme_cmd(nvmeIdmRequest *request_idm, struct nvme_admin_cmd *cmd_nvme_passthru) {
+void _fill_nvme_cmd(nvmeIdmRequest *request_idm,
+                    struct nvme_admin_cmd *cmd_nvme_passthru)
+{
+	//TODO: Leave this commented out section for nsid in-place for now.  May be needed in near future.
+	// request_idm->cmd_nvme.nsid = ioctl(fd_nvme, NVME_IOCTL_ID);
+	// if (request_idm->cmd_nvme.nsid <= 0)
+	// {
+	//     printf("%s: nsid ioctl fail: %d\n", __func__, request_idm->cmd_nvme.nsid);
+	//     ret = request_idm->cmd_nvme.nsid;
+	//     goto EXIT;
+	// }
 
-    //TODO: Leave this commented out section for nsid in-place for now.  May be needed in near future.
-    // request_idm->cmd_nvme.nsid = ioctl(fd_nvme, NVME_IOCTL_ID);
-    // if (request_idm->cmd_nvme.nsid <= 0)
-    // {
-    //     printf("%s: nsid ioctl fail: %d\n", __func__, request_idm->cmd_nvme.nsid);
-    //     ret = request_idm->cmd_nvme.nsid;
-    //     goto EXIT;
-    // }
-
-    cmd_nvme_passthru->opcode       = request_idm->cmd_nvme.opcode_nvme;
-    cmd_nvme_passthru->flags        = request_idm->cmd_nvme.flags;
-    cmd_nvme_passthru->rsvd1        = request_idm->cmd_nvme.command_id;
-    cmd_nvme_passthru->nsid         = request_idm->cmd_nvme.nsid;
-    cmd_nvme_passthru->cdw2         = request_idm->cmd_nvme.cdw2;
-    cmd_nvme_passthru->cdw3         = request_idm->cmd_nvme.cdw3;
-    cmd_nvme_passthru->metadata     = request_idm->cmd_nvme.metadata;
-    cmd_nvme_passthru->addr         = request_idm->cmd_nvme.addr;
-    cmd_nvme_passthru->metadata_len = request_idm->cmd_nvme.metadata_len;
-    cmd_nvme_passthru->data_len     = request_idm->cmd_nvme.data_len;
-    cmd_nvme_passthru->cdw10        = request_idm->cmd_nvme.ndt;
-    cmd_nvme_passthru->cdw11        = request_idm->cmd_nvme.ndm;
-    cmd_nvme_passthru->cdw12        = ((uint32_t)request_idm->cmd_nvme.rsvd2 << 16) |
-                                      ((uint32_t)request_idm->cmd_nvme.group_idm << 8) |
-                                      (uint32_t)request_idm->cmd_nvme.opcode_idm_bits7_4;
-    cmd_nvme_passthru->cdw13        = request_idm->cmd_nvme.cdw13;
-    cmd_nvme_passthru->cdw14        = request_idm->cmd_nvme.cdw14;
-    cmd_nvme_passthru->cdw15        = request_idm->cmd_nvme.cdw15;
-    cmd_nvme_passthru->timeout_ms   = request_idm->cmd_nvme.timeout_ms;
+	cmd_nvme_passthru->opcode       = request_idm->cmd_nvme.opcode_nvme;
+	cmd_nvme_passthru->flags        = request_idm->cmd_nvme.flags;
+	cmd_nvme_passthru->rsvd1        = request_idm->cmd_nvme.command_id;
+	cmd_nvme_passthru->nsid         = request_idm->cmd_nvme.nsid;
+	cmd_nvme_passthru->cdw2         = request_idm->cmd_nvme.cdw2;
+	cmd_nvme_passthru->cdw3         = request_idm->cmd_nvme.cdw3;
+	cmd_nvme_passthru->metadata     = request_idm->cmd_nvme.metadata;
+	cmd_nvme_passthru->addr         = request_idm->cmd_nvme.addr;
+	cmd_nvme_passthru->metadata_len = request_idm->cmd_nvme.metadata_len;
+	cmd_nvme_passthru->data_len     = request_idm->cmd_nvme.data_len;
+	cmd_nvme_passthru->cdw10        = request_idm->cmd_nvme.ndt;
+	cmd_nvme_passthru->cdw11        = request_idm->cmd_nvme.ndm;
+	cmd_nvme_passthru->cdw12        = ((uint32_t)request_idm->cmd_nvme.rsvd2 << 16) |
+					((uint32_t)request_idm->cmd_nvme.group_idm << 8) |
+					(uint32_t)request_idm->cmd_nvme.opcode_idm_bits7_4;
+	cmd_nvme_passthru->cdw13        = request_idm->cmd_nvme.cdw13;
+	cmd_nvme_passthru->cdw14        = request_idm->cmd_nvme.cdw14;
+	cmd_nvme_passthru->cdw15        = request_idm->cmd_nvme.cdw15;
+	cmd_nvme_passthru->timeout_ms   = request_idm->cmd_nvme.timeout_ms;
 }
 
 /**
- * _idm_cmd_check_status -  Evaluates the NVMe command status word returned from a device.
+ * _idm_cmd_check_status -  Evaluates the NVMe command status word returned
+ * from a device.
  *
- * @status:     The status code returned by a system device after the completed NVMe command request.
- * @opcode_idm: IDM-specific opcode specifying the desired IDM action performed by the device.
+ * @status:     The status code returned by a system device after the
+ *              completed NVMe command request.
+ * @opcode_idm: IDM-specific opcode specifying the desired IDM action
+ *              performed by the device.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _idm_cmd_check_status(int status, uint8_t opcode_idm) {
+int _idm_cmd_check_status(int status, uint8_t opcode_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	uint16_t sct, sc;   // status code type, status code
+	int ret;
 
-    uint16_t sct, sc;   // status code type, status code
-    int ret;
+	if (status <= 0)
+		return status;  // Just return the status code on success or pre-existing negative error.
 
-    if (status <= 0)
-        return status;  // Just return the status code on success or pre-existing negative error.
+	sc  = status & STATUS_CODE_MASK;
+	sct = (status & STATUS_CODE_TYPE_MASK) >> STATUS_CODE_TYPE_RSHIFT;
+	#ifndef COMPILE_STANDALONE
+	ilm_log_dbg("%s: for opcode_idm=0x%X: sct=0x%X, sc=0x%X", __func__, opcode_idm, sct, sc);
+	#else
+	printf("%s: for opcode_idm=0x%X: sct=0x%X, sc=0x%X\n", __func__, opcode_idm, sct, sc);
+	#endif //COMPILE_STANDALONE
 
-    sc  = status & STATUS_CODE_MASK;
-    sct = (status & STATUS_CODE_TYPE_MASK) >> STATUS_CODE_TYPE_RSHIFT;
-    #ifndef COMPILE_STANDALONE
-    ilm_log_dbg("%s: for opcode_idm=0x%X: sct=0x%X, sc=0x%X", __func__, opcode_idm, sct, sc);
-    #else
-    printf("%s: for opcode_idm=0x%X: sct=0x%X, sc=0x%X\n", __func__, opcode_idm, sct, sc);
-    #endif //COMPILE_STANDALONE
-
-    switch(sc) {
-        case NVME_IDM_ERR_MUTEX_OP_FAILURE:
+	switch(sc) {
+		case NVME_IDM_ERR_MUTEX_OP_FAILURE:
 //TODO: Replace all these with ilm_log_dbg() calls????? (If so, remove the "\n")
-            printf("NVME_IDM_ERR_MUTEX_OP_FAILURE\n");
-            ret = -EINVAL;
-            break;
-        case NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE:
-            printf("NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE\n");
-            ret = -EINVAL;
-            break;
-        case NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE:
-            printf("NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE\n");
-            ret = -EINVAL;
-            break;
-        case NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS:
-            printf("NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS\n");
-            ret = -EINVAL;
-            break;
-        case NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER:
-            printf("NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER\n");
-            ret = -EINVAL;
-            break;
-        case NVME_IDM_ERR_MUTEX_OPCODE_INVALID:
-            printf("NVME_IDM_ERR_MUTEX_OPCODE_INVALID\n");
-            ret = -EINVAL;
-            break;
-        case NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED:
-            printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED\n");
-            ret = -ENOMEM;
-            break;
-        case NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST:
-            printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST\n");
-            ret = -ENOMEM;
-            break;
-        case NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST:
-            printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST\n");
-            ret = -ENOMEM;
-            break;
-        case NVME_IDM_ERR_MUTEX_CONFLICT:   //SCSI Equivalent: Reservation Conflict
-            printf("NVME_IDM_ERR_MUTEX_CONFLICT\n");
-            switch(opcode_idm) {
-                case IDM_OPCODE_REFRESH:
-                    printf("Bad refresh: timeout\n");
-                    ret = -ETIME;
-                    break;
-                case IDM_OPCODE_UNLOCK:
-                    printf("Bad unlock\n");
-                    ret = -ENOENT;
-                    break;
-                default:
-                    printf("Busy\n");
-                    ret = -EBUSY;
-            }
-            break;
-        case NVME_IDM_ERR_MUTEX_HELD_ALREADY:   //SCSI Equivalent: Terminated
-            printf("NVME_IDM_ERR_MUTEX_HELD_ALREADY\n");
-            switch(opcode_idm) {
-                case IDM_OPCODE_REFRESH:
-                    printf("Bad refresh: timeout\n");
-                    ret = -EPERM;
-                    break;
-                case IDM_OPCODE_UNLOCK:
-                    printf("Bad unlock\n");
-                    ret = -EINVAL;
-                    break;
-                default:
-                    printf("Try again\n");
-                    ret = -EAGAIN;
-            }
-            break;
-        case NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER:    //SCSI Equivalent: Busy
-            printf("NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER\n");
-            ret = -EBUSY;
-            break;
-        default:
-            #ifndef COMPILE_STANDALONE
-            ilm_log_err("%s: unknown status code %d(0x%X)", __func__, sc, sc);
-            #else
-            printf("%s: unknown status code %d(0x%X)\n", __func__, sc, sc);
-            #endif //COMPILE_STANDALONE
-            ret = -EINVAL;
-    }
+			printf("NVME_IDM_ERR_MUTEX_OP_FAILURE\n");
+			ret = -EINVAL;
+			break;
+		case NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE:
+			printf("NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE\n");
+			ret = -EINVAL;
+			break;
+		case NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE:
+			printf("NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE\n");
+			ret = -EINVAL;
+			break;
+		case NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS:
+			printf("NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS\n");
+			ret = -EINVAL;
+			break;
+		case NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER:
+			printf("NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER\n");
+			ret = -EINVAL;
+			break;
+		case NVME_IDM_ERR_MUTEX_OPCODE_INVALID:
+			printf("NVME_IDM_ERR_MUTEX_OPCODE_INVALID\n");
+			ret = -EINVAL;
+			break;
+		case NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED:
+			printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED\n");
+			ret = -ENOMEM;
+			break;
+		case NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST:
+			printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST\n");
+			ret = -ENOMEM;
+			break;
+		case NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST:
+			printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST\n");
+			ret = -ENOMEM;
+			break;
+		case NVME_IDM_ERR_MUTEX_CONFLICT:   //SCSI Equivalent: Reservation Conflict
+			printf("NVME_IDM_ERR_MUTEX_CONFLICT\n");
+			switch(opcode_idm) {
+				case IDM_OPCODE_REFRESH:
+					printf("Bad refresh: timeout\n");
+					ret = -ETIME;
+					break;
+				case IDM_OPCODE_UNLOCK:
+					printf("Bad unlock\n");
+					ret = -ENOENT;
+					break;
+				default:
+					printf("Busy\n");
+					ret = -EBUSY;
+			}
+			break;
+		case NVME_IDM_ERR_MUTEX_HELD_ALREADY:   //SCSI Equivalent: Terminated
+			printf("NVME_IDM_ERR_MUTEX_HELD_ALREADY\n");
+			switch(opcode_idm) {
+				case IDM_OPCODE_REFRESH:
+					printf("Bad refresh: timeout\n");
+					ret = -EPERM;
+					break;
+				case IDM_OPCODE_UNLOCK:
+					printf("Bad unlock\n");
+					ret = -EINVAL;
+					break;
+				default:
+					printf("Try again\n");
+					ret = -EAGAIN;
+			}
+			break;
+		case NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER:    //SCSI Equivalent: Busy
+			printf("NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER\n");
+			ret = -EBUSY;
+			break;
+		default:
+			#ifndef COMPILE_STANDALONE
+			ilm_log_err("%s: unknown status code %d(0x%X)",
+			            __func__, sc, sc);
+			#else
+			printf("%s: unknown status code %d(0x%X)\n",
+			       __func__, sc, sc);
+			#endif //COMPILE_STANDALONE
+			ret = -EINVAL;
+	}
 
-    return ret;
+	return ret;
 }
 
 /**
- * _idm_cmd_init -  Initializes the NVMe Vendor Specific Command command struct.
+ * _idm_cmd_init -  Initializes the NVMe Vendor Specific Command command
+ * struct.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
- * @opcode_nvme:    NVMe-specific opcode specifying the desired NVMe action to perform on the IDM.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
+ * @opcode_nvme:    NVMe-specific opcode specifying the desired NVMe action to
+ *                  perform on the IDM.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme) {
+int _idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	nvmeIdmVendorCmd *cmd_nvme = &request_idm->cmd_nvme;
+	int ret = SUCCESS;
 
-    nvmeIdmVendorCmd *cmd_nvme = &request_idm->cmd_nvme;
-    int ret = SUCCESS;
+	cmd_nvme->opcode_nvme        = opcode_nvme;
+	cmd_nvme->addr               = (uint64_t)(uintptr_t)request_idm->data_idm;
+	cmd_nvme->data_len           = request_idm->data_len;
+	cmd_nvme->ndt                = request_idm->data_len / 4;
+	cmd_nvme->opcode_idm_bits7_4 = request_idm->opcode_idm << 4;
+	cmd_nvme->group_idm          = request_idm->group_idm;
+	cmd_nvme->timeout_ms         = VENDOR_CMD_TIMEOUT_DEFAULT;
 
-    cmd_nvme->opcode_nvme        = opcode_nvme;
-    cmd_nvme->addr               = (uint64_t)(uintptr_t)request_idm->data_idm;
-    cmd_nvme->data_len           = request_idm->data_len;
-    cmd_nvme->ndt                = request_idm->data_len / 4;
-    cmd_nvme->opcode_idm_bits7_4 = request_idm->opcode_idm << 4;
-    cmd_nvme->group_idm          = request_idm->group_idm;
-    cmd_nvme->timeout_ms         = VENDOR_CMD_TIMEOUT_DEFAULT;
-
-    return ret;
+	return ret;
 }
 
 /**
- * _idm_data_init_wrt -  Initializes the IDM's data struct prior to an IDM write.
+ * _idm_data_init_wrt -  Initializes the IDM's data struct prior to an
+ * IDM write.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _idm_data_init_wrt(nvmeIdmRequest *request_idm) {
+int _idm_data_init_wrt(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	idmData *data_idm = request_idm->data_idm;
+	int ret           = SUCCESS;
 
-    idmData *data_idm = request_idm->data_idm;
-    int ret           = SUCCESS;
+	#ifndef COMPILE_STANDALONE
+	data_idm->time_now  = __bswap_64(ilm_read_utc_time());
+	#else
+	data_idm->time_now  = __bswap_64(1234567890);
+	#endif //COMPILE_STANDALONE
+	data_idm->countdown = __bswap_64(request_idm->timeout);
+	data_idm->class     = __bswap_64(request_idm->class);
 
-    #ifndef COMPILE_STANDALONE
-  	data_idm->time_now  = __bswap_64(ilm_read_utc_time());
-    #else
-  	data_idm->time_now  = __bswap_64(1234567890);
-    #endif //COMPILE_STANDALONE
-    data_idm->countdown = __bswap_64(request_idm->timeout);
-    data_idm->class     = __bswap_64(request_idm->class);
-
-    bswap_char_arr(data_idm->host_id,      request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
-    bswap_char_arr(data_idm->resource_id,  request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
-    bswap_char_arr(data_idm->resource_ver, request_idm->lvb    , IDM_LVB_LEN_BYTES);
-    data_idm->resource_ver[0] = request_idm->res_ver_type;
+	bswap_char_arr(data_idm->host_id,      request_idm->host_id, IDM_HOST_ID_LEN_BYTES);
+	bswap_char_arr(data_idm->resource_id,  request_idm->lock_id, IDM_LOCK_ID_LEN_BYTES);
+	bswap_char_arr(data_idm->resource_ver, request_idm->lvb    , IDM_LVB_LEN_BYTES);
+	data_idm->resource_ver[0] = request_idm->res_ver_type;
 
 //TODO: DELETE.  Frederick's exact data payload used during firmware debug
-  	// data_idm->state           = 0x1111111111111111;
-  	// data_idm->time_now        = 0x1111111111111111;
-    // data_idm->countdown       = 0x6666666666777777;
-    // data_idm->class           = 0x0;
-    // data_idm->resource_ver[0] = (char)0x01;
-    // data_idm->resource_ver[1] = (char)0x00;
-    // data_idm->resource_ver[2] = (char)0x11;
-    // data_idm->resource_ver[3] = (char)0x11;
-    // data_idm->resource_ver[4] = (char)0x33;
-    // data_idm->resource_ver[5] = (char)0x21;
-    // data_idm->resource_ver[6] = (char)0x2E;
-    // data_idm->resource_ver[7] = (char)0xEE;
-    // memset(data_idm->rsvd0, 0x0, IDM_DATA_RESERVED_0_LEN_BYTES);
-    // data_idm->resource_id[60] = (char)0x11;
-    // data_idm->resource_id[61] = (char)0x11;
-    // data_idm->resource_id[62] = (char)0x11;
-    // data_idm->resource_id[63] = (char)0x11;
-    // data_idm->metadata[62]    = (char)0xFE;
-    // data_idm->metadata[63]    = (char)0xED;
-    // memset(data_idm->host_id, 0x31, IDM_HOST_ID_LEN_BYTES);
-    // data_idm->rsvd1[30]       = (char)0xCC;
-    // data_idm->rsvd1[31]       = (char)0xCC;
+	// data_idm->state           = 0x1111111111111111;
+	// data_idm->time_now        = 0x1111111111111111;
+	// data_idm->countdown       = 0x6666666666777777;
+	// data_idm->class           = 0x0;
+	// data_idm->resource_ver[0] = (char)0x01;
+	// data_idm->resource_ver[1] = (char)0x00;
+	// data_idm->resource_ver[2] = (char)0x11;
+	// data_idm->resource_ver[3] = (char)0x11;
+	// data_idm->resource_ver[4] = (char)0x33;
+	// data_idm->resource_ver[5] = (char)0x21;
+	// data_idm->resource_ver[6] = (char)0x2E;
+	// data_idm->resource_ver[7] = (char)0xEE;
+	// memset(data_idm->rsvd0, 0x0, IDM_DATA_RESERVED_0_LEN_BYTES);
+	// data_idm->resource_id[60] = (char)0x11;
+	// data_idm->resource_id[61] = (char)0x11;
+	// data_idm->resource_id[62] = (char)0x11;
+	// data_idm->resource_id[63] = (char)0x11;
+	// data_idm->metadata[62]    = (char)0xFE;
+	// data_idm->metadata[63]    = (char)0xED;
+	// memset(data_idm->host_id, 0x31, IDM_HOST_ID_LEN_BYTES);
+	// data_idm->rsvd1[30]       = (char)0xCC;
+	// data_idm->rsvd1[31]       = (char)0xCC;
 
-    return ret;
+	return ret;
 }
 
 /**
- * _sync_idm_cmd_send - Forms and then sends an NVMe IDM command to the system device.
- * Does so by transfering data from the "request_idm" struct to the final "nvme_passthru_cmd"
- * struct used by the system.
+ * _sync_idm_cmd_send - Forms and then sends an NVMe IDM command to the
+ * system device.
+ * Does so by transfering data from the "request_idm" struct to the final
+ * "nvme_passthru_cmd" struct used by the system.
  *
- * @request_idm:    Struct containing all NVMe-specific command info for the requested IDM action.
+ * @request_idm:    Struct containing all NVMe-specific command info for the
+ *                  requested IDM action.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _sync_idm_cmd_send(nvmeIdmRequest *request_idm) {
+int _sync_idm_cmd_send(nvmeIdmRequest *request_idm)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
 
-    #ifdef FUNCTION_ENTRY_DEBUG
-    printf("%s: START\n", __func__);
-    #endif //FUNCTION_ENTRY_DEBUG
+	struct nvme_passthru_cmd cmd_nvme_passthru;
+	int fd_nvme;
+	int ret = SUCCESS;
 
-    struct nvme_passthru_cmd cmd_nvme_passthru;
-    int fd_nvme;
-    int ret = SUCCESS;
+	//TODO: Put this under a debug flag of some kind??
+	dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
+	dumpIdmDataStruct(request_idm->data_idm);
 
-    //TODO: Put this under a debug flag of some kind??
-    dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
-    dumpIdmDataStruct(request_idm->data_idm);
+	memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
-    memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
+	fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
+	if (fd_nvme < 0) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: error opening drive %s fd %d",
+		            __func__, request_idm->drive, fd_nvme);
+		#else
+		printf("%s: error opening drive %s fd %d\n",
+		       __func__, request_idm->drive, fd_nvme);
+		#endif //COMPILE_STANDALONE
+		return fd_nvme;
+	}
 
-    fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
-    if (fd_nvme < 0) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: error opening drive %s fd %d", __func__, request_idm->drive, fd_nvme);
-        #else
-        printf("%s: error opening drive %s fd %d\n", __func__, request_idm->drive, fd_nvme);
-        #endif //COMPILE_STANDALONE
-        return fd_nvme;
-    }
+	_fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
 
-    _fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
+	//TODO: Keep?  Add debug flag?
+	dumpNvmePassthruCmd(&cmd_nvme_passthru);
 
-    //TODO: Keep?  Add debug flag?
-    dumpNvmePassthruCmd(&cmd_nvme_passthru);
+	//ioctl()'s return value comes from:
+	//  NVMe Completion Queue Entry (CQE) DWORD3:
+	//    DW3[31:17] - Status Bit Field Definitions
+	//      DW3[31]:    Do Not Retry (DNR)
+	//      DW3[30]:    More (M)
+	//      DW3[29:28]: Command Retry Delay (CRD)
+	//      DW3[27:25]: Status Code Type (SCT)
+	//      DW3[24:17]: Status Code (SC)
+	//Refer to the NVMe spec for more details.
+	//
+	//So, here, ioctl()'s return value is defined as:
+	//  ret[14]:    Do Not Retry (DNR)
+	//  ret[13]:    More (M)
+	//  ret[12:11]: Command Retry Delay (CRD)
+	//  ret[10:8]:  Status Code Type (SCT)
+	//  ret[7:0]:   Status Code (SC)
+	//NOTE: Only SC and SCT are actively used by the IDM firmware.
+	//          The rest are "normally" 0.  However, the system can use them.
+	ret = ioctl(fd_nvme, NVME_IOCTL_ADMIN_CMD, &cmd_nvme_passthru);
+	if(ret) {
+		#ifndef COMPILE_STANDALONE
+		ilm_log_err("%s: ioctl failed: %d(0x%X)", __func__, ret, ret);
+		#else
+		printf("%s: ioctl failed: %d(0x%X)\n", __func__, ret, ret);
+		#endif //COMPILE_STANDALONE
+	}
 
-    //ioctl()'s return value comes from:
-    //  NVMe Completion Queue Entry (CQE) DWORD3:
-    //    DW3[31:17] - Status Bit Field Definitions
-    //      DW3[31]:    Do Not Retry (DNR)
-    //      DW3[30]:    More (M)
-    //      DW3[29:28]: Command Retry Delay (CRD)
-    //      DW3[27:25]: Status Code Type (SCT)
-    //      DW3[24:17]: Status Code (SC)
-    //Refer to the NVMe spec for more details.
-    //
-    //So, here, ioctl()'s return value is defined as:
-    //  ret[14]:    Do Not Retry (DNR)
-    //  ret[13]:    More (M)
-    //  ret[12:11]: Command Retry Delay (CRD)
-    //  ret[10:8]:  Status Code Type (SCT)
-    //  ret[7:0]:   Status Code (SC)
-    //NOTE: Only SC and SCT are actively used by the IDM firmware.
-    //          The rest are "normally" 0.  However, the system can use them.
-    ret = ioctl(fd_nvme, NVME_IOCTL_ADMIN_CMD, &cmd_nvme_passthru);
-    if(ret) {
-        #ifndef COMPILE_STANDALONE
-        ilm_log_err("%s: ioctl failed: %d(0x%X)", __func__, ret, ret);
-        #else
-        printf("%s: ioctl failed: %d(0x%X)\n", __func__, ret, ret);
-        #endif //COMPILE_STANDALONE
-    }
+	ret = _idm_cmd_check_status(ret, request_idm->opcode_idm);
 
-    ret = _idm_cmd_check_status(ret, request_idm->opcode_idm);
-
-    close(fd_nvme);
-    return ret;
+	close(fd_nvme);
+	return ret;
 }
 
 

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -72,7 +72,7 @@
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_data_rcv(nvmeIdmRequest *request_idm, int *result)
+int nvme_idm_async_data_rcv(struct idm_nvme_request *request_idm, int *result)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -107,7 +107,7 @@ int nvme_idm_async_data_rcv(nvmeIdmRequest *request_idm, int *result)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_read(nvmeIdmRequest *request_idm)
+int nvme_idm_async_read(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -147,7 +147,7 @@ int nvme_idm_async_read(nvmeIdmRequest *request_idm)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_async_write(nvmeIdmRequest *request_idm)
+int nvme_idm_async_write(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -184,7 +184,7 @@ int nvme_idm_async_write(nvmeIdmRequest *request_idm)
  * @request_idm:    Struct containing all NVMe-specific command info for the
  *                  requested IDM action.
  */
-void nvme_idm_read_init(char *drive, nvmeIdmRequest *request_idm)
+void nvme_idm_read_init(char *drive, struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -215,7 +215,7 @@ void nvme_idm_read_init(char *drive, nvmeIdmRequest *request_idm)
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
 int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
-                        uint64_t timeout, nvmeIdmRequest *request_idm)
+                        uint64_t timeout, struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -260,7 +260,7 @@ int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_read(nvmeIdmRequest *request_idm)
+int nvme_idm_sync_read(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -285,9 +285,9 @@ int nvme_idm_sync_read(nvmeIdmRequest *request_idm)
 
 //TODO: Put on debug flag OR remove??
 	#ifndef COMPILE_STANDALONE
-	ilm_log_dbg("%s: retrieved idmData", __func__);
+	ilm_log_dbg("%s: retrieved struct idm_data", __func__);
 	#else
-	printf("%s: retrieved idmData\n", __func__);
+	printf("%s: retrieved struct idm_data\n", __func__);
 	#endif //COMPILE_STANDALONE
 	dumpIdmDataStruct(request_idm->data_idm);
 
@@ -306,7 +306,7 @@ int nvme_idm_sync_read(nvmeIdmRequest *request_idm)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int nvme_idm_sync_write(nvmeIdmRequest *request_idm)
+int nvme_idm_sync_write(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -343,7 +343,7 @@ int nvme_idm_sync_write(nvmeIdmRequest *request_idm)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _async_idm_cmd_send(nvmeIdmRequest *request_idm)
+int _async_idm_cmd_send(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -406,7 +406,7 @@ EXIT:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _async_idm_data_rcv(nvmeIdmRequest *request_idm, int *result)
+int _async_idm_data_rcv(struct idm_nvme_request *request_idm, int *result)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -491,7 +491,7 @@ EXIT:
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-void _fill_nvme_cmd(nvmeIdmRequest *request_idm,
+void _fill_nvme_cmd(struct idm_nvme_request *request_idm,
                     struct nvme_admin_cmd *cmd_nvme_passthru)
 {
 	//TODO: Leave this commented out section for nsid in-place for now.  May be needed in near future.
@@ -654,13 +654,13 @@ int _idm_cmd_check_status(int status, uint8_t opcode_idm)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme)
+int _idm_cmd_init(struct idm_nvme_request *request_idm, uint8_t opcode_nvme)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	nvmeIdmVendorCmd *cmd_nvme = &request_idm->cmd_nvme;
+	struct nvme_idm_vendor_cmd *cmd_nvme = &request_idm->cmd_nvme;
 	int ret = SUCCESS;
 
 	cmd_nvme->opcode_nvme        = opcode_nvme;
@@ -683,13 +683,13 @@ int _idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _idm_data_init_wrt(nvmeIdmRequest *request_idm)
+int _idm_data_init_wrt(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	idmData *data_idm = request_idm->data_idm;
+	struct idm_data *data_idm = request_idm->data_idm;
 	int ret           = SUCCESS;
 
 	#ifndef COMPILE_STANDALONE
@@ -743,7 +743,7 @@ int _idm_data_init_wrt(nvmeIdmRequest *request_idm)
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int _sync_idm_cmd_send(nvmeIdmRequest *request_idm)
+int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -844,7 +844,7 @@ int main(int argc, char *argv[])
             uint64_t    timeout     = 10;
 
             //Create required input structs the IDM API would normally create
-            nvmeIdmRequest *request_idm;
+            struct idm_nvme_request *request_idm;
             int            ret = SUCCESS;
 
             ret = nvme_idm_write_init(lock_id, mode, host_id,drive, timeout, 0, 0,

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -135,7 +135,8 @@ int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
 
 int _async_idm_cmd_send(nvmeIdmRequest *request_idm);  // Uses write()   (_scsi_write())
 int _async_idm_data_rcv(nvmeIdmRequest *request_idm, int *result); // Uses read()    (_scsi_read()) (ALWAYS returns status code.  MAY fill data)
-void _fill_nvme_cmd(nvmeIdmRequest *request_idm, struct nvme_passthru_cmd *cmd_nvme_passthru);
+void _fill_nvme_cmd(nvmeIdmRequest *request_idm,
+                    struct nvme_admin_cmd *cmd_nvme_passthru);
 int _idm_cmd_check_status(int status, uint8_t opcode_idm);
 int _idm_cmd_init(nvmeIdmRequest *request_idm, uint8_t opcode_nvme);
 int _idm_data_init_wrt(nvmeIdmRequest *request_idm);

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -106,7 +106,7 @@ struct idm_nvme_request {
 
     //IDM core structs
     struct nvme_idm_vendor_cmd  cmd_nvme;
-    struct idm_data                     *data_idm;
+    struct idm_data             *data_idm;
 
     //Generally, these values are cached here in the API-layer, and then
     //stored in their final location in the IO-layer.

--- a/src/idm_nvme_io_admin.h
+++ b/src/idm_nvme_io_admin.h
@@ -180,7 +180,8 @@ typedef struct _nvmeIDCtrl {
 //////////////////////////////////////////
 int nvme_admin_identify(char *drive);
 
-void _gen_nvme_cmd_identify(struct nvme_admin_cmd *cmd_admin, nvmeIDCtrl *data_identify_ctrl);
+void _gen_nvme_cmd_identify(struct nvme_admin_cmd *cmd_admin,
+                            nvmeIDCtrl *data_identify_ctrl);
 int _send_nvme_cmd_admin(char *drive, struct nvme_admin_cmd *cmd_admin);
 
 #endif /*__IDM_NVME_IO_ADMIN_H__ */

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -4,6 +4,9 @@
  * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
  *
  * idm_nvme_utils.c - Contains nvme-related helper utility functions.
+ *
+ * There are several violations of the 80 char line limit.
+ * This is on purpose to make the code easier to read.
  */
 
 #include <byteswap.h>
@@ -15,136 +18,138 @@
 //TODO: switch all "printf" to appropriate log functions from this project's log.h
 
 /**
- * dumpIdmDataStruct - Convenience function for pretty printing the contends of the
- *                     passed in data struct.
+ * dumpIdmDataStruct - Convenience function for pretty printing the contends of
+ * the passed in data struct.
  *
  * @d: Data structure for sending and receiving IDM-specifc data.
  */
-void dumpIdmDataStruct(idmData *d){
-
-    printf("idmData struct: fields\n");
-    printf("=======================\n");
-    printf("state\\ignored0     = 0x%.16"PRIX64" (%lu)\n", d->state,    d->state);
-    printf("modified\\time_now  = 0x%.16"PRIX64" (%lu)\n", d->modified, d->modified);
-    printf("countdown          = 0x%.16"PRIX64" (%lu)\n", d->countdown, d->countdown);
-    printf("class              = 0x%.16"PRIX64" (%lu)\n", d->class,     d->class);
-    printf("resource_ver = '");
-    _print_char_arr(d->resource_ver, IDM_LVB_LEN_BYTES);
-    printf("res_ver_type = 0x%X\n", d->resource_ver[0]);
-    printf("resource_id = '");
-    _print_char_arr(d->resource_id, IDM_LOCK_ID_LEN_BYTES);
-    printf("metadata    = '");
-    _print_char_arr(d->metadata, IDM_DATA_METADATA_LEN_BYTES);
-    printf("host_id     = '");
-    _print_char_arr(d->host_id, IDM_HOST_ID_LEN_BYTES);
-    printf("\n");
+void dumpIdmDataStruct(idmData *d)
+{
+	printf("idmData struct: fields\n");
+	printf("=======================\n");
+	printf("state\\ignored0     = 0x%.16"PRIX64" (%lu)\n", d->state,    d->state);
+	printf("modified\\time_now  = 0x%.16"PRIX64" (%lu)\n", d->modified, d->modified);
+	printf("countdown          = 0x%.16"PRIX64" (%lu)\n", d->countdown, d->countdown);
+	printf("class              = 0x%.16"PRIX64" (%lu)\n", d->class,     d->class);
+	printf("resource_ver = '");
+	_print_char_arr(d->resource_ver, IDM_LVB_LEN_BYTES);
+	printf("res_ver_type = 0x%X\n", d->resource_ver[0]);
+	printf("resource_id = '");
+	_print_char_arr(d->resource_id, IDM_LOCK_ID_LEN_BYTES);
+	printf("metadata    = '");
+	_print_char_arr(d->metadata, IDM_DATA_METADATA_LEN_BYTES);
+	printf("host_id     = '");
+	_print_char_arr(d->host_id, IDM_HOST_ID_LEN_BYTES);
+	printf("\n");
 }
 
 /**
- * dumpIdmInfoStruct - Convenience function for pretty printing the contends of the
- *                     passed in data struct.
+ * dumpIdmInfoStruct - Convenience function for pretty printing the contends of
+ * the passed in data struct.
  *
  * @info: Data structure containing IDM-specific info.
  */
-void dumpIdmInfoStruct(struct idm_info *info){
-
-    printf("struct idm_info fields\n");
-    printf("======================\n");
-    printf("id      = '");
-    _print_char_arr(info->id, IDM_LOCK_ID_LEN_BYTES);
-    printf("state   = 0x%X (%d)\n", info->state, info->state);
-    printf("mode    = 0x%X (%d)\n", info->mode, info->mode);
-    printf("host_id = '");
-    _print_char_arr(info->host_id, IDM_HOST_ID_LEN_BYTES);
-    printf("last_renew_time  = 0x%.16"PRIX64" (%lu)\n", info->last_renew_time,
-                                                        info->last_renew_time);
-   printf("\n");
+void dumpIdmInfoStruct(struct idm_info *info)
+{
+	printf("struct idm_info fields\n");
+	printf("======================\n");
+	printf("id      = '");
+	_print_char_arr(info->id, IDM_LOCK_ID_LEN_BYTES);
+	printf("state   = 0x%X (%d)\n", info->state, info->state);
+	printf("mode    = 0x%X (%d)\n", info->mode, info->mode);
+	printf("host_id = '");
+	_print_char_arr(info->host_id, IDM_HOST_ID_LEN_BYTES);
+	printf("last_renew_time  = 0x%.16"PRIX64" (%lu)\n", info->last_renew_time,
+	                                                    info->last_renew_time);
+	printf("\n");
 }
 
 /**
- * dumpNvmeCmdStruct - Convenience function for pretty printing the contends of the
- *                     passed in data struct.
+ * dumpNvmeCmdStruct - Convenience function for pretty printing the contends of
+ * the passed in data struct.
  *
  * @cmd_nvme:    Data structure for NVMe Vendor Specific Commands.
  * @view_fields: Boolean flag that outputs the struct's named fields.
  * @view_cdws:   Boolean flag that outputs all the struct's data as 32-bit words.
  */
-void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields, int view_cdws) {
+void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields,
+                       int view_cdws)
+{
+	if(view_fields){
+		nvmeIdmVendorCmd *c = cmd_nvme;
 
-    if(view_fields){
-        nvmeIdmVendorCmd *c = cmd_nvme;
+		printf("nvmeIdmVendorCmd struct: fields\n");
+		printf("===========================\n");
+		printf("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)\n", c->opcode_nvme,  c->opcode_nvme);
+		printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", c->flags,        c->flags);
+		printf("command_id   (CDW0[32:16]) = 0x%.4X (%u)\n", c->command_id,   c->command_id);
+		printf("nsid         (CDW1[32:0])  = 0x%.8X (%u)\n", c->nsid,         c->nsid);
+		printf("cdw2         (CDW2[32:0])  = 0x%.8X (%u)\n", c->cdw2,         c->cdw2);
+		printf("cdw3         (CDW3[32:0])  = 0x%.8X (%u)\n", c->cdw3,         c->cdw3);
+		printf("metadata     (CDW5&4[64:0])= 0x%.16"PRIX64" (%lu)\n",c->metadata, c->metadata);
+		printf("addr         (CDW7&6[64:0])= 0x%.16"PRIX64" (%lu)\n",c->addr, c->addr);
+		printf("metadata_len (CDW8[32:0])  = 0x%.8X (%u)\n", c->metadata_len, c->metadata_len);
+		printf("data_len     (CDW9[32:0])  = 0x%.8X (%u)\n", c->data_len,     c->data_len);
+		printf("ndt          (CDW10[32:0]) = 0x%.8X (%u)\n", c->ndt,          c->ndt);
+		printf("ndm          (CDW11[32:0]) = 0x%.8X (%u)\n", c->ndm,          c->ndm);
+		printf("opcode_idm_bits7_4(CDW12[ 7:0]) = 0x%.2X (%u)\n", c->opcode_idm_bits7_4, c->opcode_idm_bits7_4);
+		printf("group_idm    (CDW12[15:8]) = 0x%.2X (%u)\n", c->group_idm,    c->group_idm);
+		printf("rsvd2        (CDW12[32:16])= 0x%.4X (%u)\n", c->rsvd2,        c->rsvd2);
+		printf("cdw13        (CDW13[32:0]) = 0x%.8X (%u)\n", c->cdw13,        c->cdw13);
+		printf("cdw14        (CDW14[32:0]) = 0x%.8X (%u)\n", c->cdw14,        c->cdw14);
+		printf("cdw15        (CDW15[32:0]) = 0x%.8X (%u)\n", c->cdw15,        c->cdw15);
+		printf("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)\n", c->timeout_ms,   c->timeout_ms);
+		printf("result       (CDW17[32:0]) = 0x%.8X (%u)\n", c->result,       c->result);
+		printf("\n");
+	}
 
-        printf("nvmeIdmVendorCmd struct: fields\n");
-        printf("===========================\n");
-        printf("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)\n", c->opcode_nvme,  c->opcode_nvme);
-        printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", c->flags,        c->flags);
-        printf("command_id   (CDW0[32:16]) = 0x%.4X (%u)\n", c->command_id,   c->command_id);
-        printf("nsid         (CDW1[32:0])  = 0x%.8X (%u)\n", c->nsid,         c->nsid);
-        printf("cdw2         (CDW2[32:0])  = 0x%.8X (%u)\n", c->cdw2,         c->cdw2);
-        printf("cdw3         (CDW3[32:0])  = 0x%.8X (%u)\n", c->cdw3,         c->cdw3);
-        printf("metadata     (CDW5&4[64:0])= 0x%.16"PRIX64" (%lu)\n",c->metadata, c->metadata);
-        printf("addr         (CDW7&6[64:0])= 0x%.16"PRIX64" (%lu)\n",c->addr, c->addr);
-        printf("metadata_len (CDW8[32:0])  = 0x%.8X (%u)\n", c->metadata_len, c->metadata_len);
-        printf("data_len     (CDW9[32:0])  = 0x%.8X (%u)\n", c->data_len,     c->data_len);
-        printf("ndt          (CDW10[32:0]) = 0x%.8X (%u)\n", c->ndt,          c->ndt);
-        printf("ndm          (CDW11[32:0]) = 0x%.8X (%u)\n", c->ndm,          c->ndm);
-        printf("opcode_idm_bits7_4(CDW12[ 7:0]) = 0x%.2X (%u)\n", c->opcode_idm_bits7_4, c->opcode_idm_bits7_4);
-        printf("group_idm    (CDW12[15:8]) = 0x%.2X (%u)\n", c->group_idm,    c->group_idm);
-        printf("rsvd2        (CDW12[32:16])= 0x%.4X (%u)\n", c->rsvd2,        c->rsvd2);
-        printf("cdw13        (CDW13[32:0]) = 0x%.8X (%u)\n", c->cdw13,        c->cdw13);
-        printf("cdw14        (CDW14[32:0]) = 0x%.8X (%u)\n", c->cdw14,        c->cdw14);
-        printf("cdw15        (CDW15[32:0]) = 0x%.8X (%u)\n", c->cdw15,        c->cdw15);
-        printf("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)\n", c->timeout_ms,   c->timeout_ms);
-        printf("result       (CDW17[32:0]) = 0x%.8X (%u)\n", c->result,       c->result);
-        printf("\n");
-    }
+	if(view_cdws){
+		uint32_t *cdw = (uint32_t*)cmd_nvme;
+		int i;
 
-    if(view_cdws){
-        uint32_t *cdw = (uint32_t*)cmd_nvme;
-        int i;
-
-        printf("nvmeIdmVendorCmd struct: CDWs (hex)\n");
-        printf("===============================\n");
-        for(i = 0; i <= 17; i++) {
-            printf("cdw%.2d = 0x%.8X\n", i, cdw[i]);
-        }
-        printf("\n");
-    }
+		printf("nvmeIdmVendorCmd struct: CDWs (hex)\n");
+		printf("===============================\n");
+		for(i = 0; i <= 17; i++) {
+			printf("cdw%.2d = 0x%.8X\n", i, cdw[i]);
+		}
+		printf("\n");
+	}
 }
 
-void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd) {
-
-    printf("\n");
-    printf("nvme_passthru_cmd struct: fields\n");
-    printf("================================\n");
-    printf("opcode       (CDW0[ 7:0])  = 0x%.2X (%u)\n", cmd->opcode,       cmd->opcode);
-    printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", cmd->flags,        cmd->flags);
-    printf("rsvd1        (CDW0[32:16]) = 0x%.4X (%u)\n", cmd->rsvd1,        cmd->rsvd1);
-    printf("nsid         (CDW1[32:0])  = 0x%.8X (%u)\n", cmd->nsid,         cmd->nsid);
-    printf("cdw2         (CDW2[32:0])  = 0x%.8X (%u)\n", cmd->cdw2,         cmd->cdw2);
-    printf("cdw3         (CDW3[32:0])  = 0x%.8X (%u)\n", cmd->cdw3,         cmd->cdw3);
-    printf("metadata     (CDW5&4[64:0])= 0x%.16llX (%llu)\n",cmd->metadata, cmd->metadata);
-    printf("addr         (CDW7&6[64:0])= 0x%.16llX (%llu)\n",cmd->addr,     cmd->addr);
-    printf("metadata_len (CDW8[32:0])  = 0x%.8X (%u)\n", cmd->metadata_len, cmd->metadata_len);
-    printf("data_len     (CDW9[32:0])  = 0x%.8X (%u)\n", cmd->data_len,     cmd->data_len);
-    printf("cdw10        (CDW10[32:0]) = 0x%.8X (%u)\n", cmd->cdw10,        cmd->cdw10);
-    printf("cdw11        (CDW11[32:0]) = 0x%.8X (%u)\n", cmd->cdw11,        cmd->cdw11);
-    printf("cdw12        (CDW12[32:0]) = 0x%.8X (%u)\n", cmd->cdw12,        cmd->cdw12);
-    printf("cdw13        (CDW13[32:0]) = 0x%.8X (%u)\n", cmd->cdw13,        cmd->cdw13);
-    printf("cdw14        (CDW14[32:0]) = 0x%.8X (%u)\n", cmd->cdw14,        cmd->cdw14);
-    printf("cdw15        (CDW15[32:0]) = 0x%.8X (%u)\n", cmd->cdw15,        cmd->cdw15);
-    printf("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)\n", cmd->timeout_ms,   cmd->timeout_ms);
-    printf("result       (CDW17[32:0]) = 0x%.8X (%u)\n", cmd->result,       cmd->result);
-    printf("\n");
+void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd)
+{
+	printf("\n");
+	printf("nvme_passthru_cmd struct: fields\n");
+	printf("================================\n");
+	printf("opcode       (CDW0[ 7:0])  = 0x%.2X (%u)\n", cmd->opcode,       cmd->opcode);
+	printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", cmd->flags,        cmd->flags);
+	printf("rsvd1        (CDW0[32:16]) = 0x%.4X (%u)\n", cmd->rsvd1,        cmd->rsvd1);
+	printf("nsid         (CDW1[32:0])  = 0x%.8X (%u)\n", cmd->nsid,         cmd->nsid);
+	printf("cdw2         (CDW2[32:0])  = 0x%.8X (%u)\n", cmd->cdw2,         cmd->cdw2);
+	printf("cdw3         (CDW3[32:0])  = 0x%.8X (%u)\n", cmd->cdw3,         cmd->cdw3);
+	printf("metadata     (CDW5&4[64:0])= 0x%.16llX (%llu)\n",cmd->metadata, cmd->metadata);
+	printf("addr         (CDW7&6[64:0])= 0x%.16llX (%llu)\n",cmd->addr,     cmd->addr);
+	printf("metadata_len (CDW8[32:0])  = 0x%.8X (%u)\n", cmd->metadata_len, cmd->metadata_len);
+	printf("data_len     (CDW9[32:0])  = 0x%.8X (%u)\n", cmd->data_len,     cmd->data_len);
+	printf("cdw10        (CDW10[32:0]) = 0x%.8X (%u)\n", cmd->cdw10,        cmd->cdw10);
+	printf("cdw11        (CDW11[32:0]) = 0x%.8X (%u)\n", cmd->cdw11,        cmd->cdw11);
+	printf("cdw12        (CDW12[32:0]) = 0x%.8X (%u)\n", cmd->cdw12,        cmd->cdw12);
+	printf("cdw13        (CDW13[32:0]) = 0x%.8X (%u)\n", cmd->cdw13,        cmd->cdw13);
+	printf("cdw14        (CDW14[32:0]) = 0x%.8X (%u)\n", cmd->cdw14,        cmd->cdw14);
+	printf("cdw15        (CDW15[32:0]) = 0x%.8X (%u)\n", cmd->cdw15,        cmd->cdw15);
+	printf("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)\n", cmd->timeout_ms,   cmd->timeout_ms);
+	printf("result       (CDW17[32:0]) = 0x%.8X (%u)\n", cmd->result,       cmd->result);
+	printf("\n");
 }
 
-void _print_char_arr(char *data, unsigned int len) {
-    int i;
-    for(i=0; i<len; i++) {
-        if(data[i])
-            printf("%c", data[i]);
-        else
-            printf(" ");
-    }
-    printf("'\n");
+void _print_char_arr(char *data, unsigned int len)
+{
+	int i;
+	for(i=0; i<len; i++) {
+		if(data[i])
+			printf("%c", data[i]);
+		else
+			printf(" ");
+	}
+	printf("'\n");
 }

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -51,7 +51,7 @@ void dumpIdmDataStruct(struct idm_data *d)
  */
 void dumpIdmInfoStruct(struct idm_info *info)
 {
-	printf("struct idm_info fields\n");
+	printf("struct idm_info: fields\n");
 	printf("======================\n");
 	printf("id      = '");
 	_print_char_arr(info->id, IDM_LOCK_ID_LEN_BYTES);
@@ -78,7 +78,7 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 	if(view_fields){
 		struct nvme_idm_vendor_cmd *c = cmd_nvme;
 
-		printf("struct nvme_idm_vendor_cmd struct: fields\n");
+		printf("struct nvme_idm_vendor_cmd: fields\n");
 		printf("===========================\n");
 		printf("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)\n", c->opcode_nvme,  c->opcode_nvme);
 		printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", c->flags,        c->flags);
@@ -107,7 +107,7 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 		uint32_t *cdw = (uint32_t*)cmd_nvme;
 		int i;
 
-		printf("struct nvme_idm_vendor_cmd struct: CDWs (hex)\n");
+		printf("struct nvme_idm_vendor_cmd: CDWs (hex)\n");
 		printf("===============================\n");
 		for(i = 0; i <= 17; i++) {
 			printf("cdw%.2d = 0x%.8X\n", i, cdw[i]);
@@ -119,7 +119,7 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd)
 {
 	printf("\n");
-	printf("nvme_passthru_cmd struct: fields\n");
+	printf("struct nvme_passthru_cmd: fields\n");
 	printf("================================\n");
 	printf("opcode       (CDW0[ 7:0])  = 0x%.2X (%u)\n", cmd->opcode,       cmd->opcode);
 	printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", cmd->flags,        cmd->flags);

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -23,9 +23,9 @@
  *
  * @d: Data structure for sending and receiving IDM-specifc data.
  */
-void dumpIdmDataStruct(idmData *d)
+void dumpIdmDataStruct(struct idm_data *d)
 {
-	printf("idmData struct: fields\n");
+	printf("struct idm_data struct: fields\n");
 	printf("=======================\n");
 	printf("state\\ignored0     = 0x%.16"PRIX64" (%lu)\n", d->state,    d->state);
 	printf("modified\\time_now  = 0x%.16"PRIX64" (%lu)\n", d->modified, d->modified);
@@ -72,13 +72,13 @@ void dumpIdmInfoStruct(struct idm_info *info)
  * @view_fields: Boolean flag that outputs the struct's named fields.
  * @view_cdws:   Boolean flag that outputs all the struct's data as 32-bit words.
  */
-void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields,
+void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
                        int view_cdws)
 {
 	if(view_fields){
-		nvmeIdmVendorCmd *c = cmd_nvme;
+		struct nvme_idm_vendor_cmd *c = cmd_nvme;
 
-		printf("nvmeIdmVendorCmd struct: fields\n");
+		printf("struct nvme_idm_vendor_cmd struct: fields\n");
 		printf("===========================\n");
 		printf("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)\n", c->opcode_nvme,  c->opcode_nvme);
 		printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", c->flags,        c->flags);
@@ -107,7 +107,7 @@ void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields,
 		uint32_t *cdw = (uint32_t*)cmd_nvme;
 		int i;
 
-		printf("nvmeIdmVendorCmd struct: CDWs (hex)\n");
+		printf("struct nvme_idm_vendor_cmd struct: CDWs (hex)\n");
 		printf("===============================\n");
 		for(i = 0; i <= 17; i++) {
 			printf("cdw%.2d = 0x%.8X\n", i, cdw[i]);

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -25,7 +25,7 @@
  */
 void dumpIdmDataStruct(struct idm_data *d)
 {
-	printf("struct idm_data struct: fields\n");
+	printf("struct idm_data: fields\n");
 	printf("=======================\n");
 	printf("state\\ignored0     = 0x%.16"PRIX64" (%lu)\n", d->state,    d->state);
 	printf("modified\\time_now  = 0x%.16"PRIX64" (%lu)\n", d->modified, d->modified);

--- a/src/idm_nvme_utils.h
+++ b/src/idm_nvme_utils.h
@@ -17,7 +17,8 @@
 
 void dumpIdmDataStruct(idmData *data_idm);
 void dumpIdmInfoStruct(struct idm_info *info);
-void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields, int view_cdws);
+void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields,
+                       int view_cdws);
 void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd);
 
 void _print_char_arr(char *data, unsigned int len);

--- a/src/idm_nvme_utils.h
+++ b/src/idm_nvme_utils.h
@@ -15,9 +15,9 @@
 #include "idm_nvme_io.h"
 
 
-void dumpIdmDataStruct(idmData *data_idm);
+void dumpIdmDataStruct(struct idm_data *data_idm);
 void dumpIdmInfoStruct(struct idm_info *info);
-void dumpNvmeCmdStruct(nvmeIdmVendorCmd *cmd_nvme, int view_fields,
+void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
                        int view_cdws);
 void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd);
 

--- a/src/idm_scsi.c
+++ b/src/idm_scsi.c
@@ -64,19 +64,19 @@
 #define MBYTE2(val)			((char)((val >> 16) & 0xff))
 #define MBYTE3(val)			((char)((val >> 24) & 0xff))
 
-struct idm_data {
-	uint64_t state;		/* ignored when write */
-	uint64_t time_now;
-	uint64_t countdown;
-	uint64_t class;
-	char resource_ver[8];
-	char reserved0[24];
-	char resource_id[64];
-	char metadata[64];
-	char host_id[32];
-	char reserved1[32];
-	char ignore1[256];
-};
+// struct idm_data {
+// 	uint64_t state;		/* ignored when write */
+// 	uint64_t time_now;
+// 	uint64_t countdown;
+// 	uint64_t class;
+// 	char resource_ver[8];
+// 	char reserved0[24];
+// 	char resource_id[64];
+// 	char metadata[64];
+// 	char host_id[32];
+// 	char reserved1[32];
+// 	char ignore1[256];
+// };
 
 #define SCSI_VER_INQ_LEN		6
 #define SCSI_VER_DATA_LEN		150


### PR DESCRIPTION
Fixes for coding standard violation caused by not seeing the coding standard until late in development.
Mainly whitespace changes (switching spaces to tabs), adhering to line length limit and naming convention.
For the record, I don't agree with all these rules, but I'm making them to help maintain code consistency throughout the project.