### PR TITLE
Feature/foss 524 fix cmd timeouts

### DIFF
--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -30,7 +30,7 @@
 //////////////////////////////////////////
 //TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER NVME FILES COMPILE WITH THE REST OF PROPELLER.
 #define COMPILE_STANDALONE
-#define MAIN_ACTIVATE
+// #define MAIN_ACTIVATE
 // #define FORCE_MUTEX_NUM    //TODO: HACK!!  This MUST be removed!!
 
 #define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
@@ -2737,16 +2737,16 @@ int main(int argc, char *argv[])
 
     //cli usage: idm_nvme_api lock
     if(argc >= 2){
-        char            lock_id[IDM_LOCK_ID_LEN_BYTES] = "0000000000000000000000000000000000000000000000000000000000000000";
+        char            lock_id[IDM_LOCK_ID_LEN_BYTES] = "0000000000000000000000000000000000000000000000000000000000000201";
         int             mode                           = IDM_MODE_EXCLUSIVE;
-        char            host_id[IDM_HOST_ID_LEN_BYTES] = "00000000000000000000000000000000";
-        uint64_t        timeout                        = 10;
+        char            host_id[IDM_HOST_ID_LEN_BYTES] = "00000000000000000000000000000403";
+        uint64_t        timeout                        = 10000;
         char            lvb[IDM_LVB_LEN_BYTES]         = "lvb";
         int             lvb_size                       = 5;
         uint64_t        handle;
         int             result=0;
         unsigned int    mutex_num;
-        unsigned int    info_num;
+        int             info_num;
         struct idm_info *info_list;
         int             host_state;
         int             count;

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -192,9 +192,6 @@ void nvme_idm_read_init(char *drive, struct idm_nvme_request *request_idm)
 
 	request_idm->opcode_idm = IDM_OPCODE_INIT;  //Ignored, but default for all idm reads.
 	strncpy(request_idm->drive, drive, PATH_MAX);
-//TODO: Do I need a non-zero default timeout here for NVMe reads???
-//	request_idm->timeout  = 100;
-
 }
 
 /**
@@ -679,7 +676,7 @@ int _idm_cmd_init(struct idm_nvme_request *request_idm, uint8_t opcode_nvme)
  * IDM write.
  *
  * @request_idm:    Struct containing all NVMe-specific command info for the
- *                  requested IDM action.
+ *                  requested IDM action, including the target idm_data struct.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */


### PR DESCRIPTION
No real issue here.  The temporary test timeout setting used in the stand-alone main feature was too low.  Increased it.
Also, Added non-zero lock_id and host_id test settings (so can see byte order changes).
Also, minor cleanup.