### PR TITLE
Feature/foss 479 fix idm unit tests

### DIFF
--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2727,143 +2727,144 @@ int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
 //gcc idm_nvme_io.c idm_nvme_api.c -o idm_nvme_api
 int main(int argc, char *argv[])
 {
-    char drive[PATH_MAX];
-    int  ret = 0;
+	char drive[PATH_MAX];
+	int  ret = 0;
 
-    if(argc >= 3){
-        strcpy(drive, argv[2]);
-    }
-    else {
-        strcpy(drive, DRIVE_DEFAULT_DEVICE);
-    }
+	if(argc >= 3){
+		strcpy(drive, argv[2]);
+	}
+	else {
+		strcpy(drive, DRIVE_DEFAULT_DEVICE);
+	}
 
-    //cli usage: idm_nvme_api lock
-    if(argc >= 2){
-        char            lock_id[IDM_LOCK_ID_LEN_BYTES] = "0000000000000000000000000000000000000000000000000000000000000201";
-        int             mode                           = IDM_MODE_EXCLUSIVE;
-        char            host_id[IDM_HOST_ID_LEN_BYTES] = "00000000000000000000000000000403";
-        uint64_t        timeout                        = 10000;
-        char            lvb[IDM_LVB_LEN_BYTES]         = "lvb";
-        int             lvb_size                       = 5;
-        uint64_t        handle;
-        int             result=0;
-        unsigned int    mutex_num;
-        int             info_num;
-        struct idm_info *info_list;
-        int             host_state;
-        int             count;
-        int             self;
+	//cli usage: idm_nvme_api lock
+	if(argc >= 2){
+		char            lock_id[IDM_LOCK_ID_LEN_BYTES] = "0000000000000000000000000000000000000000000000000000000000000000";
+		int             mode                           = IDM_MODE_EXCLUSIVE;
+		char            host_id[IDM_HOST_ID_LEN_BYTES] = "00000000000000000000000000000000";
+		uint64_t        timeout                        = 10000;
+		char            lvb[IDM_LVB_LEN_BYTES]         = "lvb";
+		int             lvb_size                       = 5;
+		uint64_t        handle;
+		int             result=0;
+		unsigned int    mutex_num;
+		int             info_num;
+		struct idm_info *info_list;
+		int             host_state;
+		int             count;
+		int             self;
+		int             i;
 
-        if(strcmp(argv[1], "async_get") == 0){
-            ret = nvme_idm_async_lock(lock_id, mode, host_id, drive, timeout, &handle); // dummy call, ignore error.
-            printf("'inserted lock' ret=%d\n", ret);
-            ret = nvme_idm_async_get_result(handle, &result);
-            printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
-        }
-        else if(strcmp(argv[1], "async_get_count") == 0){
-            ret = nvme_idm_async_read_lock_count(lock_id, host_id, drive, &handle); // dummy call, ignore error.
-            printf("'inserted read lock count' ret=%d\n", ret);
-            ret = nvme_idm_async_get_result_lock_count(handle, &count, &self, &result);
-            printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
-        }
-        else if(strcmp(argv[1], "async_get_mode") == 0){
-            ret = nvme_idm_async_read_lock_mode(lock_id, drive, &handle); // dummy call, ignore error.
-            printf("'inserted read lock mode' ret=%d\n", ret);
-            ret = nvme_idm_async_get_result_lock_mode(handle, &mode, &result);
-            printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
-        }
-        else if(strcmp(argv[1], "async_get_lvb") == 0){
-            ret = nvme_idm_async_read_lvb(lock_id, host_id, drive, &handle); // dummy call, ignore error.
-            printf("'inserted read lvb' ret=%d\n", ret);
-            ret = nvme_idm_async_get_result_lvb(handle, lvb, lvb_size, &result);
-            printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
-        }
-        else if(strcmp(argv[1], "async_lock") == 0){
-            ret = nvme_idm_async_lock(lock_id, mode, host_id, drive, timeout, &handle);
-        }
-        else if(strcmp(argv[1], "async_lock_break") == 0){
-            ret = nvme_idm_async_lock_break(lock_id, mode, host_id, drive, timeout, &handle);
-        }
-        else if(strcmp(argv[1], "async_lock_convert") == 0){
-            ret = nvme_idm_async_lock_convert(lock_id, mode, host_id, drive, timeout, &handle);
-        }
-        else if(strcmp(argv[1], "async_lock_destroy") == 0){
-            ret = nvme_idm_async_lock_destroy(lock_id, mode, host_id, drive, &handle);
-        }
-        else if(strcmp(argv[1], "async_lock_refresh") == 0){
-            ret = nvme_idm_async_lock_refresh(lock_id, mode, host_id, drive, timeout, &handle);
-        }
-        else if(strcmp(argv[1], "async_lock_renew") == 0){
-            ret = nvme_idm_async_lock_renew(lock_id, mode, host_id, drive, timeout, &handle);
-        }
-        else if(strcmp(argv[1], "async_read_count") == 0){
-            ret = nvme_idm_async_read_lock_count(lock_id, host_id, drive, &handle);
-        }
-        else if(strcmp(argv[1], "async_read_mode") == 0){
-            ret = nvme_idm_async_read_lock_mode(lock_id, drive, &handle);
-        }
-        else if(strcmp(argv[1], "async_read_lvb") == 0){
-            ret = nvme_idm_async_read_lvb(lock_id, host_id, drive, &handle);
-        }
-        else if(strcmp(argv[1], "async_unlock") == 0){
-            ret = nvme_idm_async_unlock(lock_id, mode, host_id, lvb, lvb_size, drive, &handle);
-        }
-        else if(strcmp(argv[1], "sync_lock") == 0){
-            ret = nvme_idm_sync_lock(lock_id, mode, host_id, drive, timeout);
-        }
-        else if(strcmp(argv[1], "sync_lock_break") == 0){
-            ret = nvme_idm_sync_lock_break(lock_id, mode, host_id, drive, timeout);
-        }
-        else if(strcmp(argv[1], "sync_lock_convert") == 0){
-            ret = nvme_idm_sync_lock_convert(lock_id, mode, host_id, drive, timeout);
-        }
-        else if(strcmp(argv[1], "sync_lock_destroy") == 0){
-            ret = nvme_idm_sync_lock_destroy(lock_id, mode, host_id, drive);
-        }
-        else if(strcmp(argv[1], "sync_lock_refresh") == 0){
-            ret = nvme_idm_sync_lock_refresh(lock_id, mode, host_id, drive, timeout);
-        }
-        else if(strcmp(argv[1], "sync_lock_renew") == 0){
-            ret = nvme_idm_sync_lock_renew(lock_id, mode, host_id, drive, timeout);
-        }
-        else if(strcmp(argv[1], "sync_read_state") == 0){
-            ret = nvme_idm_sync_read_host_state(lock_id, host_id, &host_state, drive);
-            printf("output: host_state=%d\n", host_state);
-        }
-        else if(strcmp(argv[1], "sync_read_count") == 0){
-            ret = nvme_idm_sync_read_lock_count(lock_id, host_id, &count, &self, drive);
-            printf("output: lock_count=%d, self=%d\n", count, self);
-        }
-        else if(strcmp(argv[1], "sync_read_mode") == 0){
-            ret = nvme_idm_sync_read_lock_mode(lock_id, &mode, drive);
-            printf("output: lock_mode=%d\n", mode);
-        }
-        else if(strcmp(argv[1], "sync_read_lvb") == 0){
-            //TODO: Should "lvb" be passed in with "&lvb" instead???
-            //TODO: Technically, shouldn't ALL these param be passed in like that (ie - &lock_id, &host_id, etc)??
-            ret = nvme_idm_sync_read_lvb(lock_id, host_id, lvb, lvb_size, drive);
-        }
-        else if(strcmp(argv[1], "sync_read_group") == 0){
-            ret = nvme_idm_sync_read_mutex_group(drive, &info_list, &info_num);
-            printf("output: info_num=%u\n", info_num);
-        }
-        else if(strcmp(argv[1], "sync_read_num") == 0){
-            ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
-            printf("output: mutex_num=%u\n", mutex_num);
-        }
-        else if(strcmp(argv[1], "sync_unlock") == 0){
-            ret = nvme_idm_sync_unlock(lock_id, mode, host_id, lvb, lvb_size, drive);
-        }
-        else {
-            printf("%s: invalid command option!\n", argv[1]);
-            return -1;
-        }
-        printf("'%s' exiting with %d\n", argv[1], ret);
-    }
-    else{
-        printf("No command option given\n");
-    }
+		if(strcmp(argv[1], "async_get") == 0){
+			ret = nvme_idm_async_lock(lock_id, mode, host_id, drive, timeout, &handle); // dummy call, ignore error.
+			printf("'inserted lock' ret=%d\n", ret);
+			ret = nvme_idm_async_get_result(handle, &result);
+			printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
+		}
+		else if(strcmp(argv[1], "async_get_count") == 0){
+			ret = nvme_idm_async_read_lock_count(lock_id, host_id, drive, &handle); // dummy call, ignore error.
+			printf("'inserted read lock count' ret=%d\n", ret);
+			ret = nvme_idm_async_get_result_lock_count(handle, &count, &self, &result);
+			printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
+		}
+		else if(strcmp(argv[1], "async_get_mode") == 0){
+			ret = nvme_idm_async_read_lock_mode(lock_id, drive, &handle); // dummy call, ignore error.
+			printf("'inserted read lock mode' ret=%d\n", ret);
+			ret = nvme_idm_async_get_result_lock_mode(handle, &mode, &result);
+			printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
+		}
+		else if(strcmp(argv[1], "async_get_lvb") == 0){
+			ret = nvme_idm_async_read_lvb(lock_id, host_id, drive, &handle); // dummy call, ignore error.
+			printf("'inserted read lvb' ret=%d\n", ret);
+			ret = nvme_idm_async_get_result_lvb(handle, lvb, lvb_size, &result);
+			printf("'%s' ret=%d, result=0x%X\n", argv[1], ret, result);
+		}
+		else if(strcmp(argv[1], "async_lock") == 0){
+			ret = nvme_idm_async_lock(lock_id, mode, host_id, drive, timeout, &handle);
+		}
+		else if(strcmp(argv[1], "async_lock_break") == 0){
+			ret = nvme_idm_async_lock_break(lock_id, mode, host_id, drive, timeout, &handle);
+		}
+		else if(strcmp(argv[1], "async_lock_convert") == 0){
+			ret = nvme_idm_async_lock_convert(lock_id, mode, host_id, drive, timeout, &handle);
+		}
+		else if(strcmp(argv[1], "async_lock_destroy") == 0){
+			ret = nvme_idm_async_lock_destroy(lock_id, mode, host_id, drive, &handle);
+		}
+		else if(strcmp(argv[1], "async_lock_refresh") == 0){
+			ret = nvme_idm_async_lock_refresh(lock_id, mode, host_id, drive, timeout, &handle);
+		}
+		else if(strcmp(argv[1], "async_lock_renew") == 0){
+			ret = nvme_idm_async_lock_renew(lock_id, mode, host_id, drive, timeout, &handle);
+		}
+		else if(strcmp(argv[1], "async_read_count") == 0){
+			ret = nvme_idm_async_read_lock_count(lock_id, host_id, drive, &handle);
+		}
+		else if(strcmp(argv[1], "async_read_mode") == 0){
+			ret = nvme_idm_async_read_lock_mode(lock_id, drive, &handle);
+		}
+		else if(strcmp(argv[1], "async_read_lvb") == 0){
+			ret = nvme_idm_async_read_lvb(lock_id, host_id, drive, &handle);
+		}
+		else if(strcmp(argv[1], "async_unlock") == 0){
+			ret = nvme_idm_async_unlock(lock_id, mode, host_id, lvb, lvb_size, drive, &handle);
+		}
+		else if(strcmp(argv[1], "sync_lock") == 0){
+			ret = nvme_idm_sync_lock(lock_id, mode, host_id, drive, timeout);
+		}
+		else if(strcmp(argv[1], "sync_lock_break") == 0){
+			ret = nvme_idm_sync_lock_break(lock_id, mode, host_id, drive, timeout);
+		}
+		else if(strcmp(argv[1], "sync_lock_convert") == 0){
+			ret = nvme_idm_sync_lock_convert(lock_id, mode, host_id, drive, timeout);
+		}
+		else if(strcmp(argv[1], "sync_lock_destroy") == 0){
+			ret = nvme_idm_sync_lock_destroy(lock_id, mode, host_id, drive);
+		}
+		else if(strcmp(argv[1], "sync_lock_refresh") == 0){
+			ret = nvme_idm_sync_lock_refresh(lock_id, mode, host_id, drive, timeout);
+		}
+		else if(strcmp(argv[1], "sync_lock_renew") == 0){
+			ret = nvme_idm_sync_lock_renew(lock_id, mode, host_id, drive, timeout);
+		}
+		else if(strcmp(argv[1], "sync_read_state") == 0){
+			ret = nvme_idm_sync_read_host_state(lock_id, host_id, &host_state, drive);
+			printf("output: host_state=%d\n", host_state);
+		}
+		else if(strcmp(argv[1], "sync_read_count") == 0){
+			ret = nvme_idm_sync_read_lock_count(lock_id, host_id, &count, &self, drive);
+			printf("output: lock_count=%d, self=%d\n", count, self);
+		}
+		else if(strcmp(argv[1], "sync_read_mode") == 0){
+			ret = nvme_idm_sync_read_lock_mode(lock_id, &mode, drive);
+			printf("output: lock_mode=%d\n", mode);
+		}
+		else if(strcmp(argv[1], "sync_read_lvb") == 0){
+			//TODO: Should "lvb" be passed in with "&lvb" instead???
+			//TODO: Technically, shouldn't ALL these param be passed in like that (ie - &lock_id, &host_id, etc)??
+			ret = nvme_idm_sync_read_lvb(lock_id, host_id, lvb, lvb_size, drive);
+		}
+		else if(strcmp(argv[1], "sync_read_group") == 0){
+			ret = nvme_idm_sync_read_mutex_group(drive, &info_list, &info_num);
+			printf("output: info_num=%u\n", info_num);
+		}
+		else if(strcmp(argv[1], "sync_read_num") == 0){
+			ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
+			printf("output: mutex_num=%u\n", mutex_num);
+		}
+		else if(strcmp(argv[1], "sync_unlock") == 0){
+			ret = nvme_idm_sync_unlock(lock_id, mode, host_id, lvb, lvb_size, drive);
+		}
+		else {
+			printf("%s: invalid command option!\n", argv[1]);
+			return -1;
+		}
+		printf("'%s' exiting with %d\n", argv[1], ret);
+	}
+	else{
+		printf("No command option given\n");
+	}
 
-    return ret;
+	return ret;
 }
 #endif//MAIN_ACTIVATE

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -329,7 +329,7 @@ int nvme_idm_async_lock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int ret = SUCCESS;  //TODO: Should ALL of these be initialized to FAILURE, instead of SUCCESS???  Probably going to be case-by-case
 
 	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
@@ -382,7 +382,7 @@ int nvme_idm_async_lock_break(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int ret = SUCCESS;
 
 	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
@@ -454,7 +454,7 @@ int nvme_idm_async_lock_destroy(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int ret = SUCCESS;
 
 	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
@@ -506,7 +506,7 @@ int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int ret = SUCCESS;
 
 	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
@@ -579,7 +579,7 @@ int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_read_lock_count(ASYNC_ON, lock_id, host_id, drive,
@@ -628,7 +628,7 @@ int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_read_lock_mode(ASYNC_ON, lock_id, drive, &request_idm);
@@ -678,7 +678,7 @@ int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_read_lvb(ASYNC_ON, lock_id, host_id, drive, &request_idm);
@@ -730,7 +730,7 @@ int nvme_idm_async_unlock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
@@ -811,7 +811,7 @@ int nvme_idm_sync_lock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int ret = SUCCESS;
 
 	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
@@ -859,7 +859,7 @@ int nvme_idm_sync_lock_break(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
@@ -923,7 +923,7 @@ int nvme_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int ret = SUCCESS;
 
 	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
@@ -969,7 +969,7 @@ int nvme_idm_sync_lock_refresh(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
@@ -1034,7 +1034,7 @@ int nvme_idm_sync_read_host_state(char *lock_id, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1106,7 +1106,7 @@ int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1178,7 +1178,7 @@ int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1250,7 +1250,7 @@ int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	//TODO: The -ve check below should go away cuz lvb_size should be of unsigned type.
@@ -1320,7 +1320,7 @@ int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	// Initialize the output
@@ -1388,7 +1388,7 @@ int nvme_idm_sync_read_mutex_num(char *drive, unsigned int *mutex_num)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 //TODO: The SCSI-side code tends to set this to 0 on certain failures.
@@ -1456,7 +1456,7 @@ int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	struct idm_nvme_request *request_idm;
+	struct idm_nvme_request *request_idm = NULL;
 	int            ret = SUCCESS;
 
 	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
@@ -2165,11 +2165,12 @@ void _memory_free_idm_request(struct idm_nvme_request *request_idm) {
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	if (request_idm->data_idm) {
-		free(request_idm->data_idm);
-		request_idm->data_idm = NULL;
-	}
 	if (request_idm) {
+		if (request_idm->data_idm) {
+			free(request_idm->data_idm);
+			request_idm->data_idm = NULL;
+		}
+
 		free(request_idm);
 		request_idm = NULL;
 	}

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -108,9 +108,7 @@ EXIT:
  *
  * @handle:     NVMe request handle for the previously sent NVMe cmd.
  * @count:      Returned lock count.
- *              Referenced value set to 0 on error.
  * @self:       Returned self count.
- *              Referenced value set to 0 on error.
  * @result:     Returned result (0 or -ve value) for the previously sent
  *              NVMe command.
  *
@@ -1092,9 +1090,7 @@ EXIT_FAIL:
  * @lock_id:    Lock ID (64 bytes).
  * @host_id:    Host ID (32 bytes).
  * @count:      Returned lock count.
- *              Referenced value set to 0 on error.
  * @self:       Returned self count.
- *              Referenced value set to 0 on error.
  * @drive:      Drive path name.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
@@ -2302,9 +2298,7 @@ int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state)
  * @request_idm: Struct containing all NVMe-specific command info for the
  *               requested IDM action.
  * @count:       Returned lock count.
- *               Referenced value set to 0 on error.
  * @self:        Returned self count.
- *               Referenced value set to 0 on error.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2364,10 +2364,10 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 		           IDM_LOCK_ID_LEN_BYTES))
 			continue;
 
-		if (memcmp(data_idm[i].host_id, bswap_host_id,
+		if (!memcmp(data_idm[i].host_id, bswap_host_id,
 		           IDM_HOST_ID_LEN_BYTES)) {
-		/* Must be wrong if self has been accounted */
 			if (*self) {
+				/* Must be wrong if self has been accounted */
 				#ifndef COMPILE_STANDALONE
 				ilm_log_err("%s: account self %d > 1",
 					__func__, *self);

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -590,8 +590,12 @@ int _idm_cmd_check_status(int status, uint8_t opcode_idm)
 			printf("NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST\n");
 			ret = -ENOMEM;
 			break;
-		case NVME_IDM_ERR_MUTEX_CONFLICT:   //SCSI Equivalent: Reservation Conflict
-			printf("NVME_IDM_ERR_MUTEX_CONFLICT\n");
+		case NVME_IDM_ERR_MUTEX_GROUP_INVALID:
+			printf("NVME_IDM_ERR_MUTEX_GROUP_INVALID\n");
+			ret = -ENOENT;
+			break;
+		case NVME_IDM_ERR_MUTEX_RESERVATION_CONFLICT:
+			printf("NVME_IDM_ERR_MUTEX_RESERVATION_CONFLICT\n");
 			switch(opcode_idm) {
 				case IDM_OPCODE_REFRESH:
 					printf("Bad refresh: timeout\n");
@@ -606,8 +610,8 @@ int _idm_cmd_check_status(int status, uint8_t opcode_idm)
 					ret = -EBUSY;
 			}
 			break;
-		case NVME_IDM_ERR_MUTEX_HELD_ALREADY:   //SCSI Equivalent: Terminated
-			printf("NVME_IDM_ERR_MUTEX_HELD_ALREADY\n");
+		case NVME_IDM_ERR_MUTEX_COMMAND_TERMINATED:
+			printf("NVME_IDM_ERR_MUTEX_COMMAND_TERMINATED\n");
 			switch(opcode_idm) {
 				case IDM_OPCODE_REFRESH:
 					printf("Bad refresh: timeout\n");
@@ -622,8 +626,8 @@ int _idm_cmd_check_status(int status, uint8_t opcode_idm)
 					ret = -EAGAIN;
 			}
 			break;
-		case NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER:    //SCSI Equivalent: Busy
-			printf("NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER\n");
+		case NVME_IDM_ERR_MUTEX_BUSY:
+			printf("NVME_IDM_ERR_MUTEX_BUSY\n");
 			ret = -EBUSY;
 			break;
 		default:

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -25,8 +25,8 @@
 //////////////////////////////////////////
 //Custom (vendor-specific) NVMe opcodes sent via CDW0[7:0] of struct nvme_idm_vendor_cmd
 enum nvme_idm_vendor_cmd_opcodes {
-    NVME_IDM_VENDOR_CMD_OP_WRITE = 0xC1,
-    NVME_IDM_VENDOR_CMD_OP_READ  = 0xC2,
+	NVME_IDM_VENDOR_CMD_OP_WRITE = 0xC1,
+	NVME_IDM_VENDOR_CMD_OP_READ  = 0xC2,
 };
 
 enum nvme_idm_error_codes {//ioctl() idm-specific status codes(sc) of status code type 1(sct1)
@@ -45,36 +45,35 @@ enum nvme_idm_error_codes {//ioctl() idm-specific status codes(sc) of status cod
 	NVME_IDM_ERR_MUTEX_BUSY                        = 0xCC,  // Mutex busy status (mutex held by other)                                  //SCSI Equivalent: Busy
 };
 
-
 //////////////////////////////////////////
 // Structs
 //////////////////////////////////////////
 //TODO: Add struct description HERE
 struct nvme_idm_vendor_cmd {
-    uint8_t             opcode_nvme;  //CDW0
-    uint8_t             flags;        //CDW0    psdt_bits7_6, rsvd0_bits5_2, fuse_bits1_0
-    uint16_t            command_id;   //CDW0
-    uint32_t            nsid;         //CDW1
-    uint32_t            cdw2;         //CDW2
-    uint32_t            cdw3;         //CDW3
-    uint64_t            metadata;     //CDW4 & 5
+	uint8_t             opcode_nvme;  //CDW0
+	uint8_t             flags;        //CDW0    psdt_bits7_6, rsvd0_bits5_2, fuse_bits1_0
+	uint16_t            command_id;   //CDW0
+	uint32_t            nsid;         //CDW1
+	uint32_t            cdw2;         //CDW2
+	uint32_t            cdw3;         //CDW3
+	uint64_t            metadata;     //CDW4 & 5
 //CDW 6 - 9: Used when talking to the kernel layer (via ioctl()).
-    uint64_t            addr;         //CDW6 & 7
-    uint32_t            metadata_len; //CDW8
-    uint32_t            data_len;     //CDW9
+	uint64_t            addr;         //CDW6 & 7
+	uint32_t            metadata_len; //CDW8
+	uint32_t            data_len;     //CDW9
 //CDW 6 - 9: Used when talking directly to the drive firmware layer, I think.
-    // uint64_t            prp1;        //CDW6 & 7
-    // uint64_t            prp2;        //CDW8 & 9
-    uint32_t            ndt;          //CDW10
-    uint32_t            ndm;          //CDW11
-    uint8_t             opcode_idm_bits7_4;   //CDW12   // bits[7:4].  Lower nibble reserved.
-    uint8_t             group_idm;    //CDW12
-    uint16_t            rsvd2;        //CDW12
-    uint32_t            cdw13;        //CDW13
-    uint32_t            cdw14;        //CDW14
-    uint32_t            cdw15;        //CDW15
-    uint32_t            timeout_ms;   //Same as nvme_admin_cmd when using ioctl()??
-    uint32_t            result;       //Same as nvme_admin_cmd when using ioctl()??
+	// uint64_t            prp1;        //CDW6 & 7
+	// uint64_t            prp2;        //CDW8 & 9
+	uint32_t            ndt;          //CDW10
+	uint32_t            ndm;          //CDW11
+	uint8_t             opcode_idm_bits7_4;   //CDW12   // bits[7:4].  Lower nibble reserved.
+	uint8_t             group_idm;    //CDW12
+	uint16_t            rsvd2;        //CDW12
+	uint32_t            cdw13;        //CDW13
+	uint32_t            cdw14;        //CDW14
+	uint32_t            cdw15;        //CDW15
+	uint32_t            timeout_ms;   //Same as nvme_admin_cmd when using ioctl()??
+	uint32_t            result;       //Same as nvme_admin_cmd when using ioctl()??
 };
 
 
@@ -96,29 +95,28 @@ struct nvme_idm_vendor_cmd {
 
 //TODO: Add struct description HERE
 struct idm_nvme_request {
-    //Cached "IDM API" input params
-    char                lock_id[IDM_LOCK_ID_LEN_BYTES];
-    int                 mode_idm;
-    char                host_id[IDM_HOST_ID_LEN_BYTES];
-    char                drive[PATH_MAX];
-    uint64_t            timeout;
-    char                lvb[IDM_LVB_LEN_BYTES];
-    int                 lvb_size;   //TODO: should be unsigned, but public API setup with int.  size_t anyway?
+	//Cached "IDM API" input params
+	char                lock_id[IDM_LOCK_ID_LEN_BYTES];
+	int                 mode_idm;
+	char                host_id[IDM_HOST_ID_LEN_BYTES];
+	char                drive[PATH_MAX];
+	uint64_t            timeout;
+	char                lvb[IDM_LVB_LEN_BYTES];
+	int                 lvb_size;   //TODO: should be unsigned, but public API setup with int.  size_t anyway?
 
-    //IDM core structs
-    struct nvme_idm_vendor_cmd  cmd_nvme;
-    struct idm_data             *data_idm;
+	//IDM core structs
+	struct nvme_idm_vendor_cmd  cmd_nvme;
+	struct idm_data             *data_idm;
 
-    //Generally, these values are cached here in the API-layer, and then
-    //stored in their final location in the IO-layer.
-    uint8_t             opcode_idm;
-    uint8_t             group_idm;
-    char                res_ver_type;
-    int                 data_len;      //TODO: should be unsigned.  size_t?
-    unsigned int        data_num;      //Note: Currently, this also corresponds to # of mutexes (ie: mutex_num).  //TODO: uint64_t?
-    uint64_t            class;
-    int                 fd_nvme;
-
+	//Generally, these values are cached here in the API-layer, and then
+	//stored in their final location in the IO-layer.
+	uint8_t             opcode_idm;
+	uint8_t             group_idm;
+	char                res_ver_type;
+	int                 data_len;      //TODO: should be unsigned.  size_t?
+	unsigned int        data_num;      //Note: Currently, this also corresponds to # of mutexes (ie: mutex_num).  //TODO: uint64_t?
+	uint64_t            class;
+	int                 fd_nvme;
 };
 
 

--- a/src/idm_nvme_io.h
+++ b/src/idm_nvme_io.h
@@ -29,19 +29,20 @@ enum nvme_idm_vendor_cmd_opcodes {
     NVME_IDM_VENDOR_CMD_OP_READ  = 0xC2,
 };
 
-enum nvme_idm_error_codes {
-    NVME_IDM_ERR_MUTEX_OP_FAILURE                  = 0xC0,    //SCSI Equivalent: 0x04042200
-    NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE = 0xC1,    //SCSI Equivalent: 0x04042201
-    NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE            = 0xC2,    //SCSI Equivalent: 0x04042202
-    NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS            = 0xC3,    //SCSI Equivalent: 0x04042203
-    NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER            = 0xC4,    //SCSI Equivalent: 0x04042204
-    NVME_IDM_ERR_MUTEX_OPCODE_INVALID              = 0xC5,    //SCSI Equivalent: 0x0520000A
-    NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED              = 0xC6,    //SCSI Equivalent: 0x0B550300
-    NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST         = 0xC7,    //SCSI Equivalent: 0x0B550301
-    NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST  = 0xC8,    //SCSI Equivalent: 0x0B550302
-    NVME_IDM_ERR_MUTEX_CONFLICT                    = 0xC9,    //SCSI Equivalent: Res Conf
-    NVME_IDM_ERR_MUTEX_HELD_ALREADY                = 0xCA,    //SCSI Equivalent: Terminated
-    NVME_IDM_ERR_MUTEX_HELD_BY_ANOTHER             = 0xCB,    //SCSI Equivalent: Busy
+enum nvme_idm_error_codes {//ioctl() idm-specific status codes(sc) of status code type 1(sct1)
+	NVME_IDM_ERR_MUTEX_OP_FAILURE                  = 0xC0,  // Mutex operation failed                                                   //SCSI Equivalent: 0x04042200
+	NVME_IDM_ERR_MUTEX_REVERSE_OWNER_CHECK_FAILURE = 0xC1,  // Mutex failed reverse owner check                                         //SCSI Equivalent: 0x04042201
+	NVME_IDM_ERR_MUTEX_OP_FAILURE_STATE            = 0xC2,  // Mutex operation failed for state error                                   //SCSI Equivalent: 0x04042202
+	NVME_IDM_ERR_MUTEX_OP_FAILURE_CLASS            = 0xC3,  // Mutex operation failed for class error                                   //SCSI Equivalent: 0x04042203
+	NVME_IDM_ERR_MUTEX_OP_FAILURE_OWNER            = 0xC4,  // Mutex operation failed for owner error                                   //SCSI Equivalent: 0x04042204
+	NVME_IDM_ERR_MUTEX_OPCODE_INVALID              = 0xC5,  // Mutex failed for invalid mutex opcode                                    //SCSI Equivalent: 0x0520000A
+	NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED              = 0xC6,  // Mutex limit exceeded                                                     //SCSI Equivalent: 0x0B550300
+	NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_HOST         = 0xC7,  // Mutex host limit exceeded                                                //SCSI Equivalent: 0x0B550301
+	NVME_IDM_ERR_MUTEX_LIMIT_EXCEEDED_SHARED_HOST  = 0xC8,  // Mutex number of shared hosts exceeded                                    //SCSI Equivalent: 0x0B550302
+	NVME_IDM_ERR_MUTEX_GROUP_INVALID               = 0xC9,  // Mutex failed for invalid mutex group (LBA out of range, Mutex not found) //SCSI Equivalent: 0x05210001
+	NVME_IDM_ERR_MUTEX_RESERVATION_CONFLICT        = 0xCA,  // Mutex reservation conflict status (mutex conflict)                       //SCSI Equivalent: Res Conf
+	NVME_IDM_ERR_MUTEX_COMMAND_TERMINATED          = 0xCB,  // Mutex command terminated status (mutex initiator holds the lock)         //SCSI Equivalent: Terminated
+	NVME_IDM_ERR_MUTEX_BUSY                        = 0xCC,  // Mutex busy status (mutex held by other)                                  //SCSI Equivalent: Busy
 };
 
 

--- a/src/idm_scsi.c
+++ b/src/idm_scsi.c
@@ -220,7 +220,10 @@ static int _scsi_sg_io(char *drive, uint8_t *cdb, int cdb_len,
 	sg_io_hdr_t io_hdr;
 	int sg_fd;
 	int ret, status;
-	uint8_t op = cdb[14];
+	uint8_t op = cdb[1];
+
+	if (direction == SG_DXFER_TO_DEV)
+		op = op>>4;
 
 	if ((sg_fd = open(drive, O_RDWR | O_NONBLOCK)) < 0) {
 		ilm_log_err("%s: error opening drive %s fd %d",

--- a/test/idm_api_test.py
+++ b/test/idm_api_test.py
@@ -223,11 +223,12 @@ def test_idm__sync_break_lock_1(idm_cleanup):
     a[7] = 0
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
-		    		    host_id0, a, 8, SG_DEVICE1)
-    assert ret == -16       # -EBUSY - The BreakLock() changes ownership from Host0 to Host1
+                                   host_id0, a, 8, SG_DEVICE1)
+
+    assert ret == -2     # -ENOENT (from RESERVATION_CONFLICT) - The BreakLock() changes ownership from Host0 to Host1
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
-		    		    host_id1, a, 8, SG_DEVICE1)
+                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
 def test_idm__sync_break_lock_2(idm_cleanup):
@@ -261,11 +262,12 @@ def test_idm__sync_break_lock_2(idm_cleanup):
     a[7] = 0
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
-		    		    host_id0, a, 8, SG_DEVICE1)
-    assert ret == -16       # -EBUSY - The BreakLock() changes ownership from Host0 to Host1
+                                   host_id0, a, 8, SG_DEVICE1)
+
+    assert ret == -2     # -ENOENT (from RESERVATION_CONFLICT) - The BreakLock() changes ownership from Host0 to Host1
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
-		    		    host_id1, a, 8, SG_DEVICE1)
+                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
 def test_idm__sync_break_lock_3(idm_cleanup):
@@ -299,11 +301,12 @@ def test_idm__sync_break_lock_3(idm_cleanup):
     a[7] = 0
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
-		    		    host_id0, a, 8, SG_DEVICE1)
-    assert ret == -16       # -EBUSY - The BreakLock() changes ownership from Host0 to Host1
+                                   host_id0, a, 8, SG_DEVICE1)
+
+    assert ret == -2     # -ENOENT (from RESERVATION_CONFLICT) - The BreakLock() changes ownership from Host0 to Host1
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
-		    		    host_id1, a, 8, SG_DEVICE1)
+                                   host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
 def test_idm__sync_convert_1(idm_cleanup):
@@ -376,7 +379,8 @@ def test_idm__sync_convert_3(idm_cleanup):
 
     ret = idm_api.idm_drive_convert_lock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
                                           host_id1, SG_DEVICE1, 10000)
-    assert ret == -11       #Drive returns SCSI STATUS -x22
+
+    assert ret == -1     # -ENOENT (from COMMAND_TERMINATION)
 
     a = idm_api.charArray(8)
     a[0] = 0

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 # Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
 
+"""
+Instructions for setting device paths:
+    For BLK_DEVICEX:
+        For SCSI, use the 'sd' 'dev' path (e.g.: /dev/sdb)
+        For NVMe, use the /dev/nvmeXnY path (e.g.: /dev/nvme0n1)
+    For RAW_DEVICEX:
+        For SCSI, use the cooresponding 'sg' 'dev' path (e.g.: /dev/sg1) for a given BLK_DEVICE path.
+        For NVMe, use SAME PATH used in BLK_DEVICE path
+"""
 
 #TODO: Consolidate these settings, along with the duplicate c-code settings, in a .json file
 BLK_DEVICE1 = '/dev/sd'


### PR DESCRIPTION
This PR fixes all known issues (except one (for getting the IDM version #)) for running NVMe devices on the IDM SYNCHRONOUS (not async) UNIT TEST code using the existing pytest (python) unit test framework.
(../test/idm_api_test.py)

The python unit test code tested is the SAME unit test code that is used by the IDM SCSI code.  Most of the code changes are outside the unit test code.

This ticket turned into a bit if a catch-all ticket, as multiple issue were discovered and resolved.  
They include:
- Updating Propeller status codes to match current firmware settings. (A missing update to the IDM NVMe spec caused this code misalignment)
- Fixing a bug in the legacy SCSI code that was returning the wrong error code for the `refresh` and `unlock` mutex opcodes
- Adding a NVMe "reset" command to the python unit test framework so that the drive can be properly reset without a power cycle.  (NOTE: This fix only adds the NVMe-specific command to the existing cleanup daemon (ilm_cleanup()).  However, this daemon still ONLY runs at the end of the session, NOT after each unit test.  This will be fixed in a subsequent ticket).
- Fixing a free() memory issue that occurs under certain error conditions.
- Switch the unit test framework back to initializing\cleaning up with the "raw" device paths, NOT the "block" device paths.  These were accidentally changed on a previous ticket.
- Some whitespace indentation cleanup (to compile with the coding std)
- Comment additions and cleanup.