### PR TITLE
Foss 480 fix async unit tests

### DIFF
--- a/doc/lvm_propeller_test.md
+++ b/doc/lvm_propeller_test.md
@@ -122,11 +122,15 @@ For testing without suppressing verbose console log:
 
 The section is about adding trace debug messages within the unit test methods themselves.
 
-Using print() does not appear to work with this unit test setup.  The location
-of the print() output could not be found.
-So, alternatively, the python logging module was used.
+Option #1: print()
+This option is only available if the pytest `-s` option is added when running the test.
+Caution should be used when tracing using print() as its' output can interfere with the
+regular pytest output, making the output difficult to read.
 
-At the top of the module, create the logger object.
+Option #2: import logging
+Another option is to use the python logging module.
+
+At the top of the unit test module, create the logger object.
 ```
   from logging import Logger
   _logger = Logger.getLogger(__name__)

--- a/python/Makefile
+++ b/python/Makefile
@@ -6,8 +6,15 @@ SWIG = /usr/local/bin/swig
 SWIGFLAGS = -python
 CFLAGS = -DTEST -c -fpic -I/usr/include/python3.6m -I../src
 LDFLAGS = -shared
+LDLIBS = -lpthread -luuid
+
+ANI_OBJECT_FILES = \
+	 ../src/thpool.o \
+	 ../src/ani_api.o \
+	 ../src/idm_nvme_utils.o
 
 IDM_OBJECT_FILES = \
+	 ../src/thpool.o \
 	 ../src/ani_api.o \
 	 ../src/idm_cmd_common.o \
 	 ../src/idm_nvme_api.o \
@@ -22,13 +29,13 @@ $(PYTHON_ILM_MOD): ../src/lib_client.o lib_ilm_wrap.o
 	$(LD) $(LDFLAGS) $^ -o $@
 
 $(PYTHON_IDM_API_MOD): $(IDM_OBJECT_FILES) idm_api_wrap.o
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
-$(PYTHON_ANI_API_MOD): ../src/ani_api.o ani_api_wrap.o
-	$(LD) $(LDFLAGS) $^ -o $@
+$(PYTHON_ANI_API_MOD):  $(ANI_OBJECT_FILES) ani_api_wrap.o
+	$(LD) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $? -o $@
+	$(CC) $(CFLAGS) $? $(LDLIBS) -o $@
 
 lib_ilm_wrap.c: lib_ilm.i
 	$(SWIG) $(SWIGFLAGS) $<

--- a/src/Makefile.nvme
+++ b/src/Makefile.nvme
@@ -8,7 +8,7 @@ idm_nvme_api : $(SOURCE_API)
 	echo Compile $@
 	$(CC) -D THPOOL_DEBUG -D MAIN_ACTIVATE_NVME_API $(LDLIBS) $(SOURCE_API) -o $@
 
-idm_nvme_io : $(SOURCE_API)
+idm_nvme_io : $(SOURCE_IO)
 	echo Compile $@
 	$(CC) -D THPOOL_DEBUG -D MAIN_ACTIVATE_NVME_IO $(LDLIBS) $(SOURCE_IO) -o $@
 

--- a/src/Makefile.nvme
+++ b/src/Makefile.nvme
@@ -1,15 +1,20 @@
-SOURCE_IO := idm_cmd_common.c idm_nvme_io.c idm_nvme_utils.c ani_api.c thpool.c
+SOURCE_ANI := idm_nvme_utils.c ani_api.c thpool.c
+SOURCE_IO := $(SOURCE_ANI) idm_cmd_common.c idm_nvme_io.c
 SOURCE_API := $(SOURCE_IO) idm_nvme_api.c
-LDLIBS = -lpthread -luuid -lblkid -ludev
+LDLIBS = -lpthread -luuid
 
 
 idm_nvme_api : $(SOURCE_API)
 	echo Compile $@
-	$(CC) -D THPOOL_DEBUG $(LDLIBS) $(SOURCE_API) -o $@
+	$(CC) -D THPOOL_DEBUG -D MAIN_ACTIVATE_NVME_API $(LDLIBS) $(SOURCE_API) -o $@
 
-idm_nvme_io : $(SOURCE_IO)
+idm_nvme_io : $(SOURCE_API)
 	echo Compile $@
-	$(CC) $(LDLIBS) $(SOURCE_IO) -o $@
+	$(CC) -D THPOOL_DEBUG -D MAIN_ACTIVATE_NVME_IO $(LDLIBS) $(SOURCE_IO) -o $@
+
+ani_api : $(SOURCE_ANI)
+	echo Compile $@
+	$(CC) -D THPOOL_DEBUG -D MAIN_ACTIVATE_ANI_API $(LDLIBS) $(SOURCE_ANI) -o $@
 
 idm_nvme_io_admin : idm_nvme_io_admin.c
 	echo Compile $@

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -395,7 +395,7 @@ static int table_entry_add(char *drive, int n_pool_thrds)
 	struct table_entry *entry;
 
 	index = _table_entry_find_empty();
-	if (index < 0) {
+	if (index <= 0) {
 		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: %s{%d} NOT added", __func__, drive, n_pool_thrds);
 		#elif defined(COMPILE_STANDALONE)
@@ -444,7 +444,7 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 	struct table_entry *entry;
 
 	index = _table_entry_find_index(drive);  //find existing entry and update
-	if (index < 0) {
+	if (index <= 0) {
 		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: %s{%d} NOT replaced", __func__, drive, n_pool_thrds);
 		#elif defined(COMPILE_STANDALONE)

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -41,8 +41,16 @@
 
 /* ======================= COMPILE SWITCHES========================== */
 
-// #define MAIN_ACTIVATE		//TODO: Remove after async nvme integrations
+//TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER ASYNC NVME INTEGRATION
 #define COMPILE_STANDALONE
+#ifdef MAIN_ACTIVATE_ANI_API
+#define MAIN_ACTIVATE_ANI_API 1
+#else
+#define MAIN_ACTIVATE_ANI_API 0
+#endif
+
+#define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
+
 #define DEBUG_TABLE__DRIVE_TO_POOL
 
 
@@ -546,7 +554,7 @@ static void table_destroy(void)
 
 /* ============================= MAIN =============================== */
 
-#ifdef MAIN_ACTIVATE
+#if MAIN_ACTIVATE_ANI_API
 #include <assert.h>
 
 #define DRIVE1	"/dev/nvme1n1"
@@ -642,4 +650,4 @@ int main(void){
 
 	return 0;
 }
-#endif
+#endif //MAIN_ACTIVATE_ANI_API

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -517,7 +517,7 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 
 //Updates the table with an existing entry, or, adds a new entry if not found.
 //returns: 0 on success, -1 on failure.
-static int table_entry_update(char *drive, int n_pool_thrds)
+__attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_thrds)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START: %s\n", __func__, drive);
@@ -547,7 +547,7 @@ static int table_entry_update(char *drive, int n_pool_thrds)
 }
 
 //Removes from the table an existing entry.
-static void table_entry_remove(char *drive)
+__attribute__ ((unused)) static void table_entry_remove(char *drive)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START: %s\n", __func__, drive);
@@ -598,7 +598,7 @@ static void table_destroy(void)
 	}
 }
 
-static void table_show(void)
+__attribute__ ((unused)) static void table_show(void)
 {
 	#ifdef FUNCTION_ENTRY_DEBUG
 	printf("%s: START\n", __func__);
@@ -610,7 +610,8 @@ static void table_show(void)
 	for(i = 0; i < MAX_TABLE_ENTRIES; i++){
 		entry = table_thpool[i];
 		if (entry)
-			printf("%s:     entry(%p): drive:'%s', pool(%p)\n", __func__, entry, entry->drive, entry->thpool);
+			printf("%s:     entry(%p): drive:'%s', pool(%p)\n",
+			       __func__, entry, entry->drive, entry->thpool);
 		else
 			printf("%s:     entry(%p)\n", __func__, entry);
 	}

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -60,13 +60,6 @@
 #define TABLE_ENTRY_DRIVE_BUFFER_SIZE	32
 #define NUM_POOL_THREADS		4
 
-//TODO: Implement cli compile flag????
-// #ifdef DEBUG_TABLE__DRIVE_TO_POOL
-// #define DEBUG_TABLE__DRIVE_TO_POOL 1
-// #else
-// #define DEBUG_TABLE__DRIVE_TO_POOL 0
-// #endif
-
 
 /* ========================== STRUCTURES ============================ */
 
@@ -96,12 +89,17 @@ static int  table_entry_replace(char *drive, int n_pool_thrds);
 static int  table_entry_update(char *drive, int n_pool_thrds);
 static void table_entry_remove(char *drive);
 static void table_destroy(void);
+static void table_show(void);
 
 
 /* ================== ASYNC NVME INTERFACE(ANI) ===================== */
 
 int ani_init(void)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	return table_init();
 }
 
@@ -111,6 +109,10 @@ int ani_init(void)
 // Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
 int ani_data_rcv(struct idm_nvme_request *request_idm, int *result)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	char *drive = request_idm->drive;
 	struct table_entry *entry;
 	int ret = FAILURE;
@@ -142,6 +144,10 @@ int ani_data_rcv(struct idm_nvme_request *request_idm, int *result)
 // Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
 int ani_send_cmd(struct idm_nvme_request *request_idm, unsigned long ctrl)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	char *drive                   = request_idm->drive;
 	struct arg_ioctl *arg         = request_idm->arg_async_nvme;
 	struct nvme_passthru_cmd *cmd = request_idm->cmd_nvme_passthru;
@@ -224,11 +230,19 @@ EXIT:
 
 void ani_destroy(void)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	table_destroy();
 }
 
 static int ani_ioctl(void* arg)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	struct arg_ioctl *arg_ = (struct arg_ioctl *)arg;
 
 	return ioctl(arg_->fd, arg_->ctrl, arg_->cmd);
@@ -240,6 +254,10 @@ static int ani_ioctl(void* arg)
 //return: 1 when empty, 0 when NOT empty (so behaves like logical bool)
 static int _table_entry_is_empty(struct table_entry *entry)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	if (!entry) return 1;
 
 	if ((!entry->drive) || (!entry->thpool)) return 1;
@@ -251,6 +269,10 @@ static int _table_entry_is_empty(struct table_entry *entry)
 //return: (int >= 0) on success, -1 on failure(table full)
 static int _table_entry_find_empty(void)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int i;
 	struct table_entry *entry;
 	int ret = FAILURE;
@@ -284,6 +306,10 @@ static int _table_entry_find_empty(void)
 //return: (int >= 0) on success, -1 on failure
 static int _table_entry_find_index(char *drive)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START: %s\n", __func__, drive);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int i;
 	struct table_entry *entry;
 	int ret = FAILURE;
@@ -309,9 +335,9 @@ static int _table_entry_find_index(char *drive)
 
 	if (ret >= 0){
 		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		ilm_log_dbg("%s: %s found", __func__, entry->drive);
+		ilm_log_dbg("%s: %s found at %d", __func__, entry->drive, ret);
 		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: %s found\n", __func__, entry->drive);
+		printf("%s: %s found at %d\n", __func__, entry->drive, ret);
 		#endif
 	}
 	else{
@@ -327,6 +353,10 @@ static int _table_entry_find_index(char *drive)
 //returns: 0 on success, -1 on failure.
 static int table_init(void)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int i;
 	struct table_entry *entry;
 
@@ -355,6 +385,10 @@ static int table_init(void)
 //return: valid entry ptr on success, NULL on failure
 static struct table_entry* table_entry_find(char *drive)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START: %s\n", __func__, drive);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int i;
 	struct table_entry *entry = NULL;
 
@@ -399,6 +433,10 @@ static struct table_entry* table_entry_find(char *drive)
 //returns: 0 on success, -1 on failure.
 static int table_entry_add(char *drive, int n_pool_thrds)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START: %s\n", __func__, drive);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int index;
 	struct table_entry *entry;
 
@@ -448,6 +486,10 @@ static int table_entry_add(char *drive, int n_pool_thrds)
 //returns: 0 on success, -1 on failure.
 static int table_entry_replace(char *drive, int n_pool_thrds)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START: %s\n", __func__, drive);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int index;
 	struct table_entry *entry;
 
@@ -486,6 +528,10 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 //returns: 0 on success, -1 on failure.
 static int table_entry_update(char *drive, int n_pool_thrds)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START: %s\n", __func__, drive);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int ret = FAILURE;	//assume table is full
 
 	ret = table_entry_replace(drive, n_pool_thrds);  //find existing entry and update
@@ -512,6 +558,10 @@ static int table_entry_update(char *drive, int n_pool_thrds)
 //Removes from the table an existing entry.
 static void table_entry_remove(char *drive)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START: %s\n", __func__, drive);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int index;
 	struct table_entry *entry;
 
@@ -535,6 +585,10 @@ static void table_entry_remove(char *drive)
 
 static void table_destroy(void)
 {
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
 	int i;
 	struct table_entry *entry;
 
@@ -548,6 +602,24 @@ static void table_destroy(void)
 			free(entry);
 			table_thpool[i] = NULL;
 		}
+	}
+}
+
+static void table_show(void)
+{
+	#ifdef FUNCTION_ENTRY_DEBUG
+	printf("%s: START\n", __func__);
+	#endif //FUNCTION_ENTRY_DEBUG
+
+	struct table_entry *entry;
+	int i;
+
+	for(i = 0; i < MAX_TABLE_ENTRIES; i++){
+		entry = table_thpool[i];
+		if (entry)
+			printf("%s:     entry(%p): drive:'%s', pool(%p)\n", __func__, entry, entry->drive, entry->thpool);
+		else
+			printf("%s:     entry(%p)\n", __func__, entry);
 	}
 }
 
@@ -598,11 +670,13 @@ int main(void){
 
 	ret = _table_entry_find_empty();
 	assert(ret == 1);
+	table_show();
 	printf("\n");
 
 	// Test REPLACE & public FIND
 	printf("REPLACE test\n");
 	ret = table_entry_replace((char*)DRIVE1, 6);
+	table_show();
 	assert(ret == 0);
 	entry = table_entry_find((char*)DRIVE1);
 	assert(strcmp(entry->drive, (char*)DRIVE1) == 0);
@@ -615,6 +689,7 @@ int main(void){
 	// Test UPDATE & public FIND
 	printf("UPDATE test\n");
 	ret = table_entry_update((char*)DRIVE1, 8);
+	table_show();
 	assert(ret == 0);
 	entry = table_entry_find((char*)DRIVE1);
 	assert(strcmp(entry->drive, DRIVE1) == 0);

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -1839,8 +1839,6 @@ int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
 	ret = nvme_idm_sync_read_mutex_num(drive, &mutex_num);
 	if (ret < 0)
 		return -ENOENT;
-	else if (!mutex_num)
-		return SUCCESS;
 
 	if (async_on) {
 		/*
@@ -1854,12 +1852,12 @@ int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
 		* read back 1 data block and defer to return count.
 		*/
 		if (!mutex_num)
-		mutex_num = 1;
+			mutex_num = 1;
 	}
 	else {
 		if (!mutex_num) {
-		request_idm = NULL;
-		return SUCCESS;
+			request_idm = NULL;
+			return SUCCESS;
 		}
 	}
 

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -30,7 +30,12 @@
 //////////////////////////////////////////
 //TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER NVME FILES COMPILE WITH THE REST OF PROPELLER.
 #define COMPILE_STANDALONE
-// #define MAIN_ACTIVATE
+#ifdef MAIN_ACTIVATE_NVME_API
+#define MAIN_ACTIVATE_NVME_API 1
+#else
+#define MAIN_ACTIVATE_NVME_API 0
+#endif
+
 // #define FORCE_MUTEX_NUM    //TODO: HACK!!  This MUST be removed!!
 
 #define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
@@ -2747,7 +2752,7 @@ int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
 
 
 
-#ifdef MAIN_ACTIVATE
+#if MAIN_ACTIVATE_NVME_API
 /*#########################################################################################
 ########################### STAND-ALONE MAIN ##############################################
 #########################################################################################*/
@@ -2981,4 +2986,4 @@ int main(int argc, char *argv[])
 INIT_FAIL_EXIT:
 	return ret;
 }
-#endif//MAIN_ACTIVATE
+#endif//MAIN_ACTIVATE_NVME_API

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -53,7 +53,11 @@
 //////////////////////////////////////////
 //TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER NVME FILES COMPILE WITH THE REST OF PROPELLER.
 #define COMPILE_STANDALONE
-// #define MAIN_ACTIVATE
+#ifdef MAIN_ACTIVATE_NVME_IO
+#define MAIN_ACTIVATE_NVME_IO 1
+#else
+#define MAIN_ACTIVATE_NVME_IO 0
+#endif
 
 #define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
 
@@ -729,7 +733,7 @@ int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 
 
 
-#ifdef MAIN_ACTIVATE
+#if MAIN_ACTIVATE_NVME_IO
 /*#########################################################################################
 ########################### STAND-ALONE MAIN ##############################################
 #########################################################################################*/
@@ -763,11 +767,11 @@ int main(int argc, char *argv[])
             struct idm_nvme_request *request_idm;
             int ret = FAILURE;
 
-            ret = nvme_idm_write_init(lock_id, mode, host_id,drive, timeout, 0, 0,
+            ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
                                       request_idm);
             printf("%s exiting with %d\n", argv[1], ret);
 
-            ret = nvme_idm_write(request_idm);
+            ret = nvme_idm_sync_write(request_idm);
             printf("%s exiting with %d\n", argv[1], ret);
         }
 
@@ -776,4 +780,4 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-#endif//MAIN_ACTIVATE
+#endif//MAIN_ACTIVATE_NVME_IO

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,7 +11,6 @@ import pytest
 from . import ilm_util
 
 import idm_api
-import ani_api
 from test_conf import *     # Normally bad practice, but only importing 'constants' here
 
 _logger = logging.getLogger(__name__)
@@ -92,23 +91,21 @@ Fixture for manually creating, yielding and then destroying the
 async nvme interface (ANI).
 Used by the custom async nvme code.
 """
-@pytest.fixture(scope="module")
-def ani_api_startup():
+@pytest.fixture(scope="session")
+def idm_daemon():
     ret = -1
 
     try:
-        # idm_api.idm_manual_init() #TODO: Move these to a "idm_manaul_startup" fixture??
-        ret = ani_api.ani_init()
+        ret = idm_api.idm_manual_init()
     except Exception as e:
-        _logger.error(f'ani_init failure:{e}')
+        _logger.error(f'idm_manual_init failure:{e}')
         raise e from None
 
     yield ret #TODO: just yield init ec for now.  Remove?
 
     try:
-        # idm_api.idm_manual_destroy() #TODO: Move these to a "idm_manaul_startup" fixture??
-        ani_api.ani_destroy()
+        idm_api.idm_manual_destroy()
     except Exception as e:
-        _logger.error(f'ani_destroy failure:{e}')
+        _logger.error(f'idm_manual_destroy failure:{e}')
         raise e from None
 

--- a/test/idm_api_async_test.py
+++ b/test/idm_api_async_test.py
@@ -29,7 +29,7 @@ def wait_for_scsi_response(device, handle):
 
     poll.unregister(sg_fd)
 
-def test_idm__async_lock_exclusive(idm_cleanup):
+def test_idm__async_lock_exclusive(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -65,7 +65,7 @@ def test_idm__async_lock_exclusive(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_lock_shareable(idm_cleanup):
+def test_idm__async_lock_shareable(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -101,7 +101,7 @@ def test_idm__async_lock_shareable(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_lock_exclusive_two_drives(idm_cleanup):
+def test_idm__async_lock_exclusive_two_drives(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -154,7 +154,7 @@ def test_idm__async_lock_exclusive_two_drives(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_lock_shareable_two_drives(idm_cleanup):
+def test_idm__async_lock_shareable_two_drives(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -207,7 +207,7 @@ def test_idm__async_lock_shareable_two_drives(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_lock_shareable_two_locks(idm_cleanup):
+def test_idm__async_lock_shareable_two_locks(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     lock_id1 = "0000000000000000000000000000000000000000000000000000000000000001"
@@ -261,7 +261,7 @@ def test_idm__async_lock_shareable_two_locks(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_break_lock_1(idm_cleanup):
+def test_idm__async_break_lock_1(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -327,7 +327,7 @@ def test_idm__async_break_lock_1(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_break_lock_2(idm_cleanup):
+def test_idm__async_break_lock_2(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -393,7 +393,7 @@ def test_idm__async_break_lock_2(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_break_lock_3(idm_cleanup):
+def test_idm__async_break_lock_3(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -459,7 +459,7 @@ def test_idm__async_break_lock_3(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_convert_1(idm_cleanup):
+def test_idm__async_convert_1(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -504,7 +504,7 @@ def test_idm__async_convert_1(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_convert_2(idm_cleanup):
+def test_idm__async_convert_2(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -549,7 +549,7 @@ def test_idm__async_convert_2(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_convert_3(idm_cleanup):
+def test_idm__async_convert_3(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -613,7 +613,7 @@ def test_idm__async_convert_3(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_renew_1(idm_cleanup):
+def test_idm__async_renew_1(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -684,7 +684,7 @@ def test_idm__async_renew_1(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_renew_2(idm_cleanup):
+def test_idm__async_renew_2(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -755,7 +755,7 @@ def test_idm__async_renew_2(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_renew_timout_1(idm_cleanup):
+def test_idm__async_renew_timout_1(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -802,7 +802,7 @@ def test_idm__async_renew_timout_1(idm_cleanup):
     assert ret == 0
     assert result == 0          # -ETIME or 0
 
-def test_idm__async_renew_timeout_2(idm_cleanup):
+def test_idm__async_renew_timeout_2(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -849,7 +849,7 @@ def test_idm__async_renew_timeout_2(idm_cleanup):
     assert ret == 0
     assert result == 0          # -ETIME or 0
 
-def test_idm__async_read_lvb_1(idm_cleanup):
+def test_idm__async_read_lvb_1(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -894,7 +894,7 @@ def test_idm__async_read_lvb_1(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_read_lvb_2(idm_cleanup):
+def test_idm__async_read_lvb_2(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -986,7 +986,7 @@ def test_idm__async_read_lvb_2(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_get_host_count(idm_cleanup):
+def test_idm__async_get_host_count(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -1043,7 +1043,7 @@ def test_idm__async_get_host_count(idm_cleanup):
     assert count == 0
     assert self == 0
 
-def test_idm__async_two_hosts_get_host_count(idm_cleanup):
+def test_idm__async_two_hosts_get_host_count(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -1144,7 +1144,7 @@ def test_idm__async_two_hosts_get_host_count(idm_cleanup):
     assert count == 0
     assert self == 0
 
-def test_idm__async_three_hosts_get_host_count(idm_cleanup):
+def test_idm__async_three_hosts_get_host_count(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -1265,7 +1265,7 @@ def test_idm__async_three_hosts_get_host_count(idm_cleanup):
     assert count == 0
     assert self == 0
 
-def test_idm__async_get_lock_mode(idm_cleanup):
+def test_idm__async_get_lock_mode(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -1280,7 +1280,7 @@ def test_idm__async_get_lock_mode(idm_cleanup):
     assert mode == idm_api.IDM_MODE_UNLOCK
     assert result == 0
 
-def test_idm__async_get_lock_exclusive_mode(idm_cleanup):
+def test_idm__async_get_lock_exclusive_mode(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"
@@ -1325,7 +1325,7 @@ def test_idm__async_get_lock_exclusive_mode(idm_cleanup):
     assert ret == 0
     assert result == 0
 
-def test_idm__async_get_lock_shareable_mode(idm_cleanup):
+def test_idm__async_get_lock_shareable_mode(idm_cleanup, idm_daemon):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
     host_id0 = "00000000000000000000000000000000"


### PR DESCRIPTION
Part 1 of fixes for this ticket to get all the existing async unit tests working on and NVMe device.
Currently, 21 of 23 async unit tests are passing on this branch.
Will merge this branch as is for now.  Need to move to another server to get the last 2 unit test working (a server that has multiple NVMe drives, which the last 2 tests require).  This will require additional changes on other branches due to issues elsewhere in the code. To keep things simple, relative to `main`, will just merge this now and fix the last 2 unit tests on another branch later.

For this PR:
- Made changes within the NVMe code related to memory allocation to get the unit tests passing.
- For the unit test framework, added a new `idm_daemon` that'll be used to initialize the new asynchronous NVMe interface (ANI) code that runs the new threadpools.  Added it to all the the async unit tests.
- Updated the stand-alone nvme makefile to make it easier to compile the standalone test executables.
- Add a bunch of new debug-related code (and compile switches) to make debugging easier.