### PR TITLE
Feature/FOSS-466 2 refactor debug compiles and logging

### DIFF
--- a/src/Makefile.nvme
+++ b/src/Makefile.nvme
@@ -12,15 +12,15 @@ DBG_FLAGS := \
 
 idm_nvme_api : $(SOURCE_API)
 	echo Compile $@
-	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D MAIN_ACTIVATE_NVME_API $(SOURCE_API) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D DBG__NVME_API_MAIN_ENABLE $(SOURCE_API) $(LDLIBS) -o $@
 
 idm_nvme_io : $(SOURCE_IO)
 	echo Compile $@
-	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D MAIN_ACTIVATE_NVME_IO $(SOURCE_IO) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D DBG__NVME_IO_MAIN_ENABLE $(SOURCE_IO) $(LDLIBS) -o $@
 
 ani_api : $(SOURCE_ANI)
 	echo Compile $@
-	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D MAIN_ACTIVATE_ANI_API $(SOURCE_ANI) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D DBG__NVME_ANI_MAIN_ENABLE $(SOURCE_ANI) $(LDLIBS) -o $@
 
 idm_nvme_io_admin : idm_nvme_io_admin.c
 	echo Compile $@

--- a/src/Makefile.nvme
+++ b/src/Makefile.nvme
@@ -6,17 +6,21 @@ CFLAGS := -fPIE -DPIE -D_GNU_SOURCE
 LDFLAGS = -Wl,-z,relro -pie -Wall
 LDLIBS = -lpthread -luuid
 
+DBG_FLAGS := \
+	-D TEST \
+	-D THPOOL_DEBUG
+
 idm_nvme_api : $(SOURCE_API)
 	echo Compile $@
-	$(CC) $(CFLAGS) $(LDFLAGS) -D THPOOL_DEBUG -D MAIN_ACTIVATE_NVME_API $(SOURCE_API) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D MAIN_ACTIVATE_NVME_API $(SOURCE_API) $(LDLIBS) -o $@
 
 idm_nvme_io : $(SOURCE_IO)
 	echo Compile $@
-	$(CC) $(CFLAGS) $(LDFLAGS) -D THPOOL_DEBUG -D MAIN_ACTIVATE_NVME_IO $(SOURCE_IO) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D MAIN_ACTIVATE_NVME_IO $(SOURCE_IO) $(LDLIBS) -o $@
 
 ani_api : $(SOURCE_ANI)
 	echo Compile $@
-	$(CC) $(CFLAGS) $(LDFLAGS) -D THPOOL_DEBUG -D MAIN_ACTIVATE_ANI_API $(SOURCE_ANI) $(LDLIBS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(DBG_FLAGS) -D MAIN_ACTIVATE_ANI_API $(SOURCE_ANI) $(LDLIBS) -o $@
 
 idm_nvme_io_admin : idm_nvme_io_admin.c
 	echo Compile $@

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -45,6 +45,9 @@ Setup to be gcc-defined (-D) in make file */
 /* Define for extra logging on drive-to-threadpool table interactions */
 #define DBG__THRD_POOL_TABLE
 
+/* Defines for logging struct field data for important data structs */
+#define DBG__DUMP_STRUCTS
+
 ////////////////////////////////////////////////////////////////////////////////
 // INCLUDES
 ////////////////////////////////////////////////////////////////////////////////
@@ -193,8 +196,9 @@ int ani_send_cmd(struct idm_nvme_request *request_idm, unsigned long ctrl)
 
 	uuid_generate(request_idm->uuid_async_job);
 
-	//TODO: Keep?  Add debug flag?
+	#ifdef DBG__DUMP_STRUCTS
 	dumpNvmePassthruCmd(cmd);
+	#endif
 
 	ret = thpool_add_work(entry->thpool, request_idm->uuid_async_job,
 	                      (th_func_p)ani_ioctl, (void*)arg);

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -51,7 +51,8 @@
 /* Define for logging a function's name each time it is entered. */
 #define DBG__LOG_FUNC_ENTRY
 
-#define DEBUG_TABLE__DRIVE_TO_POOL
+/* Define for extra logging on drive-to-threadpool table interactions */
+#define DBG__THRD_POOL_TABLE
 
 
 /* ========================== DEFINES ============================ */
@@ -257,7 +258,7 @@ static int _table_entry_find_empty(void)
 		}
 	}
 
-	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	#ifdef DBG__THRD_POOL_TABLE
 	if (ret >= 0)
 		ilm_log_dbg("%s: empty entry found at %d", __func__, ret);
 	else
@@ -294,7 +295,7 @@ static int _table_entry_find_index(char *drive)
 		}
 	}
 
-	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	#ifdef DBG__THRD_POOL_TABLE
 	if (ret >= 0)
 		ilm_log_dbg("%s: %s found at %d", __func__, entry->drive, ret);
 	else
@@ -358,7 +359,7 @@ static struct table_entry* table_entry_find(char *drive)
 		entry = NULL;
 	}
 
-	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	#ifdef DBG__THRD_POOL_TABLE
 	if (entry)
 		ilm_log_dbg("%s: %s found", __func__, entry->drive);
 	else
@@ -426,7 +427,7 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 		return FAILURE;
 	}
 
-	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	#ifdef DBG__THRD_POOL_TABLE
 	ilm_log_dbg("%s: %s{%d} replaced at %d\n",
 	            __func__, entry->drive,
 	            thpool_num_threads_alive(entry->thpool), index);
@@ -454,7 +455,7 @@ __attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_t
 		}
 	}
 
-	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	#ifdef DBG__THRD_POOL_TABLE
 	ilm_log_dbg("%s: %s updated", __func__, drive);
 	#endif
 
@@ -483,7 +484,7 @@ __attribute__ ((unused)) static void table_entry_remove(char *drive)
 			entry->thpool = NULL;
 		}
 
-		#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+		#ifdef DBG__THRD_POOL_TABLE
 		ilm_log_dbg("%s: %s removed", __func__, drive);
 		#endif
 	}

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -283,7 +283,7 @@ static int _table_entry_find_empty(void)
 static int _table_entry_find_index(char *drive)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
-	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	ilm_log_dbg("%s: ENTRY w\\ %s", __func__, drive);
 	#endif
 
 	int i;
@@ -348,7 +348,7 @@ static int table_init(void)
 static struct table_entry* table_entry_find(char *drive)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
-	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	ilm_log_dbg("%s: ENTRY w\\ %s", __func__, drive);
 	#endif
 
 	int i;
@@ -384,7 +384,7 @@ static struct table_entry* table_entry_find(char *drive)
 static int table_entry_add(char *drive, int n_pool_thrds)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
-	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	ilm_log_dbg("%s: ENTRY w\\ %s", __func__, drive);
 	#endif
 
 	int index;
@@ -417,7 +417,7 @@ static int table_entry_add(char *drive, int n_pool_thrds)
 static int table_entry_replace(char *drive, int n_pool_thrds)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
-	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	ilm_log_dbg("%s: ENTRY w\\ %s", __func__, drive);
 	#endif
 
 	int index;
@@ -438,7 +438,7 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 	}
 
 	#ifdef DBG__THRD_POOL_TABLE
-	ilm_log_dbg("%s: %s{%d} replaced at %d\n",
+	ilm_log_dbg("%s: %s{%d} replaced at %d",
 	            __func__, entry->drive,
 	            thpool_num_threads_alive(entry->thpool), index);
 	#endif
@@ -451,7 +451,7 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 __attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_thrds)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
-	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	ilm_log_dbg("%s: ENTRY w\\ %s", __func__, drive);
 	#endif
 
 	int ret = FAILURE;	//assume table is full
@@ -476,7 +476,7 @@ __attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_t
 __attribute__ ((unused)) static void table_entry_remove(char *drive)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
-	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	ilm_log_dbg("%s: ENTRY w\\ %s", __func__, drive);
 	#endif
 
 	int index;
@@ -534,10 +534,10 @@ __attribute__ ((unused)) static void table_show(void)
 	for(i = 0; i < MAX_TABLE_ENTRIES; i++){
 		entry = table_thpool[i];
 		if (entry)
-			printf("%s:     entry(%p): drive:'%s', pool(%p)\n",
-			       __func__, entry, entry->drive, entry->thpool);
+			ilm_log_dbg("%s:     entry(%p): drive:'%s', pool(%p)",
+			             __func__, entry, entry->drive, entry->thpool);
 		else
-			printf("%s:     entry(%p)\n", __func__, entry);
+			ilm_log_dbg("%s:     entry(%p)", __func__, entry);
 	}
 }
 

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -36,13 +36,14 @@
 
 #include "ani_api.h"
 #include "idm_nvme_utils.h"
+#include "log.h"
 #include "thpool.h"
 
 
 /* ======================= COMPILE SWITCHES========================== */
 
 //TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER ASYNC NVME INTEGRATION
-#define COMPILE_STANDALONE
+// #define COMPILE_STANDALONE
 #ifdef MAIN_ACTIVATE_ANI_API
 #define MAIN_ACTIVATE_ANI_API 1
 #else

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -42,8 +42,6 @@
 
 /* ======================= COMPILE SWITCHES========================== */
 
-//TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER ASYNC NVME INTEGRATION
-// #define COMPILE_STANDALONE
 #ifdef MAIN_ACTIVATE_ANI_API
 #define MAIN_ACTIVATE_ANI_API 1
 #else
@@ -120,22 +118,14 @@ int ani_data_rcv(struct idm_nvme_request *request_idm, int *result)
 
 	entry = table_entry_find(drive);
 	if (!entry){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: find fail: %s", __func__, drive);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: find fail: %s\n", __func__, drive);
-		#endif
 		return FAILURE;
 	}
 
 	ret = thpool_find_result(entry->thpool, request_idm->uuid_async_job,
 	                         10000, 10000, result); //TODO: Fix hard-coded values
 	if (ret){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: add work fail: %s", __func__, drive);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: add work fail: %s\n", __func__, drive);
-		#endif
 		ret = FAILURE;
 	}
 
@@ -160,21 +150,13 @@ int ani_send_cmd(struct idm_nvme_request *request_idm, unsigned long ctrl)
 		//Auto-create new thpool for drive
 		ret = table_entry_add(drive, NUM_POOL_THREADS);
 		if (ret){
-			#if !defined(COMPILE_STANDALONE)
 			ilm_log_err("%s: add entry fail: %s", __func__, drive);
-			#elif defined(COMPILE_STANDALONE)
-			printf("%s: add entry fail: %s\n", __func__, drive);
-			#endif
 			ret = FAILURE;
 			goto EXIT;
 		}
 		entry = table_entry_find(drive);
 		if (!entry){
-			#if !defined(COMPILE_STANDALONE)
 			ilm_log_err("%s: find fail: %s", __func__, drive);
-			#elif defined(COMPILE_STANDALONE)
-			printf("%s: find fail: %s\n", __func__, drive);
-			#endif
 			ret = FAILURE;
 			goto EXIT;
 		}
@@ -185,22 +167,14 @@ int ani_send_cmd(struct idm_nvme_request *request_idm, unsigned long ctrl)
 	//This way, this memory will be freed when request_idm is freed.
 	arg = (struct arg_ioctl*)calloc(1, sizeof(*arg));
 	if (!arg){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: arg calloc fail: drive %s", __func__, drive);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: arg calloc fail: drive %s\n", __func__, drive);
-		#endif
 		ret = -ENOMEM;
 		goto EXIT;
 	}
 
 	cmd = (struct nvme_passthru_cmd *)calloc(1, sizeof(*cmd));
 	if (!cmd){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: cmd calloc fai: drive %s", __func__, drive);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: cmd calloc fai: drive %s\n", __func__, drive);
-		#endif
 		ret = -ENOMEM;
 		goto EXIT;
 	}
@@ -218,11 +192,7 @@ int ani_send_cmd(struct idm_nvme_request *request_idm, unsigned long ctrl)
 	ret = thpool_add_work(entry->thpool, request_idm->uuid_async_job,
 	                      (th_func_p)ani_ioctl, (void*)arg);
 	if (ret){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: add work fail: %s", __func__, drive);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: add work fail: %s\n", __func__, drive);
-		#endif
 		ret = FAILURE;
 	}
 EXIT:
@@ -286,20 +256,13 @@ static int _table_entry_find_empty(void)
 		}
 	}
 
-	if (ret >= 0){
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	if (ret >= 0)
 		ilm_log_dbg("%s: empty entry found at %d", __func__, ret);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: empty entry found at %d\n", __func__, ret);
-		#endif
-	}
-	else{
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	else
 		ilm_log_dbg("%s: empty entry NOT found", __func__);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: empty entry NOT found\n", __func__);
-		#endif
-	}
+	#endif
+
 	return ret;
 }
 
@@ -316,11 +279,7 @@ static int _table_entry_find_index(char *drive)
 	int ret = FAILURE;
 
 	if (!drive){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: invalid param", __func__);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: invalid param\n", __func__);
-		#endif
 		return FAILURE;
 	}
 
@@ -334,20 +293,13 @@ static int _table_entry_find_index(char *drive)
 		}
 	}
 
-	if (ret >= 0){
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	if (ret >= 0)
 		ilm_log_dbg("%s: %s found at %d", __func__, entry->drive, ret);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: %s found at %d\n", __func__, entry->drive, ret);
-		#endif
-	}
-	else{
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	else
 		ilm_log_dbg("%s: %s NOT found", __func__, drive);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: %s NOT found\n", __func__, drive);
-		#endif
-	}
+	#endif
+
 	return ret;
 }
 
@@ -370,11 +322,7 @@ static int table_init(void)
 		entry = (struct table_entry *)calloc(MAX_TABLE_ENTRIES, sizeof(*entry));
 		if (!entry) {
 			table_destroy();
-			#if !defined(COMPILE_STANDALONE)
 			ilm_log_err("%s: calloc failure", __func__);
-			#elif defined(COMPILE_STANDALONE)
-			printf("%s: calloc failure\n", __func__);
-			#endif
 			return FAILURE;
 		}
 		table_thpool[i] = entry;
@@ -395,11 +343,7 @@ static struct table_entry* table_entry_find(char *drive)
 	struct table_entry *entry = NULL;
 
 	if (!drive){
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: invalid param", __func__);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: invalid param\n", __func__);
-		#endif
 		return NULL;
 	}
 
@@ -413,20 +357,12 @@ static struct table_entry* table_entry_find(char *drive)
 		entry = NULL;
 	}
 
-	if (entry){
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
+	if (entry)
 		ilm_log_dbg("%s: %s found", __func__, entry->drive);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: %s found\n", __func__, entry->drive);
-		#endif
-	}
-	else{
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	else
 		ilm_log_dbg("%s: %s NOT found", __func__, drive);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: %s NOT found\n", __func__, drive);
-		#endif
-	}
+	#endif
 
 	return entry;
 }
@@ -444,11 +380,7 @@ static int table_entry_add(char *drive, int n_pool_thrds)
 
 	index = _table_entry_find_empty();
 	if (index < 0) {
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: %s{%d} NOT added", __func__, drive, n_pool_thrds);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: %s{%d} NOT added\n", __func__, drive, n_pool_thrds);
-		#endif
 		return FAILURE;
 	}
 
@@ -461,15 +393,9 @@ static int table_entry_add(char *drive, int n_pool_thrds)
 		return FAILURE;
 	}
 
-	#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
 	ilm_log_err("%s: %s{%d} added at %d",
 			__func__, entry->drive,
 			thpool_num_threads_alive(entry->thpool), index);
-	#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-	printf("%s: %s{%d} added at %d\n",
-		__func__, entry->drive,
-		thpool_num_threads_alive(entry->thpool), index);
-	#endif
 
 	return SUCCESS;
 }
@@ -487,11 +413,7 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 
 	index = _table_entry_find_index(drive);  //find existing entry and update
 	if (index < 0) {
-		#if !defined(COMPILE_STANDALONE)
 		ilm_log_err("%s: %s{%d} NOT replaced", __func__, drive, n_pool_thrds);
-		#elif defined(COMPILE_STANDALONE)
-		printf("%s: %s{%d} NOT replaced\n", __func__, drive, n_pool_thrds);
-		#endif
 		return FAILURE;
 	}
 
@@ -503,14 +425,10 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 		return FAILURE;
 	}
 
-	#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
 	ilm_log_dbg("%s: %s{%d} replaced at %d\n",
 	            __func__, entry->drive,
 	            thpool_num_threads_alive(entry->thpool), index);
-	#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-	printf("%s: %s{%d} replaced at %d\n",
-	       __func__, entry->drive,
-	       thpool_num_threads_alive(entry->thpool), index);
 	#endif
 
 	return SUCCESS;
@@ -530,20 +448,15 @@ __attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_t
 	if (ret) {
 		ret = table_entry_add(drive, n_pool_thrds);  //find empty entry
 		if (ret) {
-			#if !defined(COMPILE_STANDALONE)
 			ilm_log_err("%s: %s NOT updated", __func__, drive);
-			#elif defined(COMPILE_STANDALONE)
-			printf("%s: %s NOT updated\n", __func__, drive);
-			#endif
 			return ret;
 		}
 	}
 
-	#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+	#ifdef DEBUG_TABLE__DRIVE_TO_POOL
 	ilm_log_dbg("%s: %s updated", __func__, drive);
-	#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-	printf("%s: %s updated\n", __func__, drive);
 	#endif
+
 	return SUCCESS;
 }
 
@@ -569,10 +482,8 @@ __attribute__ ((unused)) static void table_entry_remove(char *drive)
 			entry->thpool = NULL;
 		}
 
-		#if !defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
+		#ifdef DEBUG_TABLE__DRIVE_TO_POOL
 		ilm_log_dbg("%s: %s removed", __func__, drive);
-		#elif defined(COMPILE_STANDALONE) && defined(DEBUG_TABLE__DRIVE_TO_POOL)
-		printf("%s: %s removed\n", __func__, drive);
 		#endif
 	}
 }

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -42,10 +42,12 @@
 
 /* ======================= COMPILE SWITCHES========================== */
 
-#ifdef MAIN_ACTIVATE_ANI_API
-#define MAIN_ACTIVATE_ANI_API 1
+/* For using internal main() for stand-alone debug compilation.
+Setup to be gcc-defined (-D) in make file */
+#ifdef DBG__NVME_ANI_MAIN_ENABLE
+#define DBG__NVME_ANI_MAIN_ENABLE 1
 #else
-#define MAIN_ACTIVATE_ANI_API 0
+#define DBG__NVME_ANI_MAIN_ENABLE 0
 #endif
 
 /* Define for logging a function's name each time it is entered. */
@@ -534,7 +536,7 @@ __attribute__ ((unused)) static void table_show(void)
 
 /* ============================= MAIN =============================== */
 
-#if MAIN_ACTIVATE_ANI_API
+#if DBG__NVME_ANI_MAIN_ENABLE
 #include <assert.h>
 
 #define DRIVE1	"/dev/nvme1n1"
@@ -636,4 +638,4 @@ int main(void){
 
 	return 0;
 }
-#endif //MAIN_ACTIVATE_ANI_API
+#endif //DBG__NVME_ANI_MAIN_ENABLE

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -48,7 +48,8 @@
 #define MAIN_ACTIVATE_ANI_API 0
 #endif
 
-#define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
+/* Define for logging a function's name each time it is entered. */
+#define DBG__LOG_FUNC_ENTRY
 
 #define DEBUG_TABLE__DRIVE_TO_POOL
 
@@ -95,9 +96,9 @@ static void table_show(void);
 
 int ani_init(void)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	return table_init();
 }
@@ -108,9 +109,9 @@ int ani_init(void)
 // Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
 int ani_data_rcv(struct idm_nvme_request *request_idm, int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	char *drive = request_idm->drive;
 	struct table_entry *entry;
@@ -135,9 +136,9 @@ int ani_data_rcv(struct idm_nvme_request *request_idm, int *result)
 // Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
 int ani_send_cmd(struct idm_nvme_request *request_idm, unsigned long ctrl)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	char *drive                   = request_idm->drive;
 	struct arg_ioctl *arg         = request_idm->arg_async_nvme;
@@ -201,18 +202,18 @@ EXIT:
 
 void ani_destroy(void)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	table_destroy();
 }
 
 static int ani_ioctl(void* arg)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct arg_ioctl *arg_ = (struct arg_ioctl *)arg;
 
@@ -225,9 +226,9 @@ static int ani_ioctl(void* arg)
 //return: 1 when empty, 0 when NOT empty (so behaves like logical bool)
 static int _table_entry_is_empty(struct table_entry *entry)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	if (!entry) return 1; //TODO: This is actually an error.  Should never happen
 
@@ -240,9 +241,9 @@ static int _table_entry_is_empty(struct table_entry *entry)
 //return: (int >= 0) on success, -1 on failure(table full)
 static int _table_entry_find_empty(void)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int i;
 	struct table_entry *entry;
@@ -270,9 +271,9 @@ static int _table_entry_find_empty(void)
 //return: (int >= 0) on success, -1 on failure
 static int _table_entry_find_index(char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START: %s\n", __func__, drive);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	#endif
 
 	int i;
 	struct table_entry *entry;
@@ -306,9 +307,9 @@ static int _table_entry_find_index(char *drive)
 //returns: 0 on success, -1 on failure.
 static int table_init(void)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int i;
 	struct table_entry *entry;
@@ -335,9 +336,9 @@ static int table_init(void)
 //return: valid entry ptr on success, NULL on failure
 static struct table_entry* table_entry_find(char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START: %s\n", __func__, drive);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	#endif
 
 	int i;
 	struct table_entry *entry = NULL;
@@ -371,9 +372,9 @@ static struct table_entry* table_entry_find(char *drive)
 //returns: 0 on success, -1 on failure.
 static int table_entry_add(char *drive, int n_pool_thrds)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START: %s\n", __func__, drive);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	#endif
 
 	int index;
 	struct table_entry *entry;
@@ -404,9 +405,9 @@ static int table_entry_add(char *drive, int n_pool_thrds)
 //returns: 0 on success, -1 on failure.
 static int table_entry_replace(char *drive, int n_pool_thrds)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START: %s\n", __func__, drive);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	#endif
 
 	int index;
 	struct table_entry *entry;
@@ -438,9 +439,9 @@ static int table_entry_replace(char *drive, int n_pool_thrds)
 //returns: 0 on success, -1 on failure.
 __attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_thrds)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START: %s\n", __func__, drive);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	#endif
 
 	int ret = FAILURE;	//assume table is full
 
@@ -463,9 +464,9 @@ __attribute__ ((unused)) static int table_entry_update(char *drive, int n_pool_t
 //Removes from the table an existing entry.
 __attribute__ ((unused)) static void table_entry_remove(char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START: %s\n", __func__, drive);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY w\\ %s\n", __func__, drive);
+	#endif
 
 	int index;
 	struct table_entry *entry;
@@ -490,9 +491,9 @@ __attribute__ ((unused)) static void table_entry_remove(char *drive)
 
 static void table_destroy(void)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int i;
 	struct table_entry *entry;
@@ -512,9 +513,9 @@ static void table_destroy(void)
 
 __attribute__ ((unused)) static void table_show(void)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct table_entry *entry;
 	int i;

--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -28,20 +28,9 @@
 				Other?
  */
 
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <uuid/uuid.h>
-
-#include "ani_api.h"
-#include "idm_nvme_utils.h"
-#include "log.h"
-#include "thpool.h"
-
-
-/* ======================= COMPILE SWITCHES========================== */
-
+////////////////////////////////////////////////////////////////////////////////
+// COMPILE SWITCHES
+////////////////////////////////////////////////////////////////////////////////
 /* For using internal main() for stand-alone debug compilation.
 Setup to be gcc-defined (-D) in make file */
 #ifdef DBG__NVME_ANI_MAIN_ENABLE
@@ -56,30 +45,44 @@ Setup to be gcc-defined (-D) in make file */
 /* Define for extra logging on drive-to-threadpool table interactions */
 #define DBG__THRD_POOL_TABLE
 
+////////////////////////////////////////////////////////////////////////////////
+// INCLUDES
+////////////////////////////////////////////////////////////////////////////////
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <uuid/uuid.h>
 
-/* ========================== DEFINES ============================ */
+#include "ani_api.h"
+#include "idm_nvme_utils.h"
+#include "log.h"
+#include "thpool.h"
 
+////////////////////////////////////////////////////////////////////////////////
+// DEFINES
+////////////////////////////////////////////////////////////////////////////////
 #define MAX_TABLE_ENTRIES		8
 #define TABLE_ENTRY_DRIVE_BUFFER_SIZE	32
 #define NUM_POOL_THREADS		4
 
-
-/* ========================== STRUCTURES ============================ */
-
+////////////////////////////////////////////////////////////////////////////////
+// STRUCTURES
+////////////////////////////////////////////////////////////////////////////////
 struct table_entry {
 	char              drive[PATH_MAX];
 	struct threadpool *thpool;
 };
 
-
-/* =========================== GLOBLALS ============================= */
-
+////////////////////////////////////////////////////////////////////////////////
+// GLOBALS
+////////////////////////////////////////////////////////////////////////////////
 //Primary drive-to-threadpool table
 struct table_entry *table_thpool[MAX_TABLE_ENTRIES];
 
-
-/* ========================== PROTOTYPES ============================ */
-
+////////////////////////////////////////////////////////////////////////////////
+// PROTOTYPES
+////////////////////////////////////////////////////////////////////////////////
 static int ani_ioctl(void* arg);
 
 static int  _table_entry_is_empty(struct table_entry *entry);
@@ -94,9 +97,9 @@ static void table_entry_remove(char *drive);
 static void table_destroy(void);
 static void table_show(void);
 
-
-/* ================== ASYNC NVME INTERFACE(ANI) ===================== */
-
+////////////////////////////////////////////////////////////////////////////////
+// ASYNC NVME INTERFACE(ANI)
+////////////////////////////////////////////////////////////////////////////////
 int ani_init(void)
 {
 	#ifdef DBG__LOG_FUNC_ENTRY
@@ -224,8 +227,9 @@ static int ani_ioctl(void* arg)
 }
 
 
-/* ========================== LOOKUP TABLE ============================ */
-
+////////////////////////////////////////////////////////////////////////////////
+// LOOKUP TABLE
+////////////////////////////////////////////////////////////////////////////////
 //return: 1 when empty, 0 when NOT empty (so behaves like logical bool)
 static int _table_entry_is_empty(struct table_entry *entry)
 {
@@ -533,9 +537,9 @@ __attribute__ ((unused)) static void table_show(void)
 	}
 }
 
-
-/* ============================= MAIN =============================== */
-
+////////////////////////////////////////////////////////////////////////////////
+// DEBUG MAIN
+////////////////////////////////////////////////////////////////////////////////
 #if DBG__NVME_ANI_MAIN_ENABLE
 #include <assert.h>
 

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -31,10 +31,12 @@
 //////////////////////////////////////////
 // COMPILE FLAGS
 //////////////////////////////////////////
-#ifdef MAIN_ACTIVATE_NVME_API
-#define MAIN_ACTIVATE_NVME_API 1
+/* For using internal main() for stand-alone debug compilation.
+Setup to be gcc-defined (-D) in make file */
+#ifdef DBG__NVME_API_MAIN_ENABLE
+#define DBG__NVME_API_MAIN_ENABLE 1
 #else
-#define MAIN_ACTIVATE_NVME_API 0
+#define DBG__NVME_API_MAIN_ENABLE 0
 #endif
 
 /* Define for logging a function's name each time it is entered. */
@@ -2355,7 +2357,7 @@ int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
 
 
 
-#if MAIN_ACTIVATE_NVME_API
+#if DBG__NVME_API_MAIN_ENABLE
 /*#########################################################################################
 ########################### STAND-ALONE MAIN ##############################################
 #########################################################################################*/
@@ -2588,4 +2590,4 @@ int main(int argc, char *argv[])
 INIT_FAIL_EXIT:
 	return ret;
 }
-#endif//MAIN_ACTIVATE_NVME_API
+#endif//DBG__NVME_API_MAIN_ENABLE

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -37,7 +37,8 @@
 #define MAIN_ACTIVATE_NVME_API 0
 #endif
 
-#define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
+/* Define for logging a function's name each time it is entered. */
+#define DBG__LOG_FUNC_ENTRY
 
 //////////////////////////////////////////
 // FUNCTIONS
@@ -52,6 +53,10 @@
  */
 void nvme_idm_async_free_result(uint64_t handle)
 {
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
+
 	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 
 	_memory_free_idm_request(request_idm);
@@ -68,9 +73,9 @@ void nvme_idm_async_free_result(uint64_t handle)
  */
 int nvme_idm_async_get_result(uint64_t handle, int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int ret;
@@ -111,9 +116,9 @@ EXIT:
 int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count,
                                          int *self, int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int ret;
@@ -163,9 +168,9 @@ EXIT_FAIL:
 int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode,
                                         int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int ret;
@@ -213,9 +218,9 @@ EXIT_FAIL:
 int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size,
                                   int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = (struct idm_nvme_request *)handle;
 	int ret;
@@ -266,9 +271,9 @@ EXIT_FAIL:
 int nvme_idm_async_lock(char *lock_id, int mode, char *host_id,
                         char *drive, uint64_t timeout, uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -311,9 +316,9 @@ EXIT:
 int nvme_idm_async_lock_break(char *lock_id, int mode, char *host_id,
                               char *drive, uint64_t timeout, uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -375,9 +380,9 @@ int nvme_idm_async_lock_convert(char *lock_id, int mode, char *host_id,
 int nvme_idm_async_lock_destroy(char *lock_id, int mode, char *host_id,
                                 char *drive, uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -419,9 +424,9 @@ int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
                                 char *drive, uint64_t timeout,
                                 uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -484,9 +489,9 @@ int nvme_idm_async_lock_renew(char *lock_id, int mode, char *host_id,
 int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive,
                                    uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -525,9 +530,9 @@ EXIT:
  */
 int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -567,9 +572,9 @@ EXIT:
 int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive,
                             uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -611,9 +616,9 @@ int nvme_idm_async_unlock(char *lock_id, int mode, char *host_id,
                           char *lvb, int lvb_size, char *drive,
                           uint64_t *handle)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -702,9 +707,9 @@ int nvme_idm_read_version(int *version, char *drive)
 int nvme_idm_sync_lock(char *lock_id, int mode, char *host_id,
                        char *drive, uint64_t timeout)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -742,9 +747,9 @@ EXIT:
 int nvme_idm_sync_lock_break(char *lock_id, int mode, char *host_id,
                              char *drive, uint64_t timeout)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -798,9 +803,9 @@ int nvme_idm_sync_lock_convert(char *lock_id, int mode, char *host_id,
 int nvme_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id,
                                char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -836,9 +841,9 @@ EXIT:
 int nvme_idm_sync_lock_refresh(char *lock_id, int mode, char *host_id,
                                   char *drive, uint64_t timeout)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -893,9 +898,9 @@ int nvme_idm_sync_lock_renew(char *lock_id, int mode, char *host_id,
 int nvme_idm_sync_read_host_state(char *lock_id, char *host_id,
                                   int *host_state, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -946,9 +951,9 @@ EXIT_FAIL:
 int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
                                   int *self, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -1001,9 +1006,9 @@ EXIT_FAIL:
  */
 int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -1057,9 +1062,9 @@ EXIT_FAIL:
 int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
                            int lvb_size, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -1113,9 +1118,9 @@ EXIT_FAIL:
 int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
                                    int *info_num)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -1165,9 +1170,9 @@ EXIT_FAIL:
  */
 int nvme_idm_sync_read_mutex_num(char *drive, unsigned int *mutex_num)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -1211,9 +1216,9 @@ EXIT_FAIL:
 int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
                          char *lvb, int lvb_size, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_nvme_request *request_idm = NULL;
 	int ret;
@@ -1252,9 +1257,9 @@ EXIT:
 int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
                uint64_t timeout, struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -1303,9 +1308,9 @@ int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
 int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
                      uint64_t timeout, struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -1353,9 +1358,9 @@ int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
 int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
                        struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -1404,9 +1409,9 @@ int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
 int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
                        uint64_t timeout, struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -1453,9 +1458,9 @@ int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
 int _init_read_host_state(char *lock_id, char *host_id, char *drive,
                           struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	unsigned int mutex_num = 0;
 	int ret;
@@ -1501,9 +1506,9 @@ int _init_read_host_state(char *lock_id, char *host_id, char *drive,
 int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
                           char *drive, struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	unsigned int mutex_num = 0;
 	int ret;
@@ -1567,9 +1572,9 @@ int _init_read_lock_count(int async_on, char *lock_id, char *host_id,
 int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
                          struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	unsigned int mutex_num = 0;
 	int ret;
@@ -1635,9 +1640,9 @@ int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
 int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
                    struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	unsigned int mutex_num = 0;
 	int ret;
@@ -1697,9 +1702,9 @@ int _init_read_lvb(int async_on, char *lock_id, char *host_id, char *drive,
  */
 int _init_read_mutex_group(char *drive, struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	unsigned int mutex_num = 0;
 	int ret;
@@ -1740,9 +1745,9 @@ int _init_read_mutex_group(char *drive, struct idm_nvme_request **request_idm)
  */
 int _init_read_mutex_num(char *drive, struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -1783,9 +1788,9 @@ int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
                  int lvb_size, char *drive,
 		 struct idm_nvme_request **request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -1835,9 +1840,9 @@ int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
  */
 void _memory_free_idm_request(struct idm_nvme_request *request_idm) {
 
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	if (request_idm) {
 		if (request_idm->arg_async_nvme) {
@@ -1874,9 +1879,9 @@ void _memory_free_idm_request(struct idm_nvme_request *request_idm) {
 int _memory_init_idm_request(struct idm_nvme_request **request_idm,
                              unsigned int data_num)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int data_len;
 
@@ -1916,9 +1921,9 @@ int _memory_init_idm_request(struct idm_nvme_request **request_idm,
  */
 int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_data    *data_idm;
 	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
@@ -1969,9 +1974,9 @@ int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state)
 int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
                       int *self)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_data    *data_idm;
 	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
@@ -2043,9 +2048,9 @@ EXIT:
  */
 int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_data    *data_idm;
 	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
@@ -2117,9 +2122,9 @@ EXIT:
  */
 int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_data    *data_idm;
 	char               bswap_lock_id[IDM_LOCK_ID_LEN_BYTES];
@@ -2169,9 +2174,9 @@ int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size)
 int _parse_mutex_group(struct idm_nvme_request *request_idm,
                        struct idm_info **info_ptr, int *info_num)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_data    *data_idm;
 	unsigned int       mutex_num = request_idm->data_num;
@@ -2253,9 +2258,9 @@ EXIT:
 void _parse_mutex_num(struct idm_nvme_request *request_idm,
                       unsigned int *mutex_num)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	/*
 	NOTE: Propeller firmware returns the mutex counts in a unique format.
@@ -2302,9 +2307,9 @@ void _parse_mutex_num(struct idm_nvme_request *request_idm,
  */
 int _validate_input_common(char *lock_id, char *host_id, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	if (ilm_inject_fault_is_hit())
 		return -EIO;
@@ -2328,9 +2333,9 @@ int _validate_input_common(char *lock_id, char *host_id, char *drive)
  */
 int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret = FAILURE;
 

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -7,11 +7,32 @@
  *
  *
  * NOTES on IDM API:
- * The term IDM API is defined here as a "top" level interface consisting of functions that
- * interact with or manipulate the IDM.  The functions in this file represent the NVMe-specific versions
- * of the IDM APIs.  These IDM APIs are then intended to be called externally by programs such as linux's lvm2.
+ * The term IDM (In-Drive Mutex) API is defined here as the main interface to
+ * the "lower-level" of the Propeller code (in that "lower" is "closer" to
+ * the hardware).  These functions interact with the OS to write and\or read
+ * to the target device's IDM. The functions in this file represent the
+ * NVMe-specific versions of the IDM APIs.  These IDM APIs are intended to be
+ * called by the ILM "layer" of Propeller (which is, in turn, called by external
+ * programs such as Linux's lvm2.
  */
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPILE FLAGS
+////////////////////////////////////////////////////////////////////////////////
+/* For using internal main() for stand-alone debug compilation.
+Setup to be gcc-defined (-D) in make file */
+#ifdef DBG__NVME_API_MAIN_ENABLE
+#define DBG__NVME_API_MAIN_ENABLE 1
+#else
+#define DBG__NVME_API_MAIN_ENABLE 0
+#endif
+
+/* Define for logging a function's name each time it is entered. */
+#define DBG__LOG_FUNC_ENTRY
+
+////////////////////////////////////////////////////////////////////////////////
+// INCLUDES
+////////////////////////////////////////////////////////////////////////////////
 #include <byteswap.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -27,24 +48,9 @@
 #include "log.h"
 #include "util.h"
 
-
-//////////////////////////////////////////
-// COMPILE FLAGS
-//////////////////////////////////////////
-/* For using internal main() for stand-alone debug compilation.
-Setup to be gcc-defined (-D) in make file */
-#ifdef DBG__NVME_API_MAIN_ENABLE
-#define DBG__NVME_API_MAIN_ENABLE 1
-#else
-#define DBG__NVME_API_MAIN_ENABLE 0
-#endif
-
-/* Define for logging a function's name each time it is entered. */
-#define DBG__LOG_FUNC_ENTRY
-
-//////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 // FUNCTIONS
-//////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 /**
  * nvme_idm_async_free_result - Free the async result
@@ -2357,10 +2363,10 @@ int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
 
 
 
+////////////////////////////////////////////////////////////////////////////////
+// DEBUG MAIN
+////////////////////////////////////////////////////////////////////////////////
 #if DBG__NVME_API_MAIN_ENABLE
-/*#########################################################################################
-########################### STAND-ALONE MAIN ##############################################
-#########################################################################################*/
 #define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1"
 
 #define ASYNC_SLEEP_TIME_SEC	1

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2010-2011 Red Hat, Inc.
- * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2023 Seagate Technology LLC and/or its Affiliates.
  *
  * idm_nvme_api.c - Primary NVMe interface for In-drive Mutex (IDM)
  *
@@ -31,8 +31,6 @@
 //////////////////////////////////////////
 // COMPILE FLAGS
 //////////////////////////////////////////
-//TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER NVME FILES COMPILE WITH THE REST OF PROPELLER.
-// #define COMPILE_STANDALONE
 #ifdef MAIN_ACTIVATE_NVME_API
 #define MAIN_ACTIVATE_NVME_API 1
 #else
@@ -79,13 +77,8 @@ int nvme_idm_async_get_result(uint64_t handle, int *result)
 
 	ret = nvme_idm_async_data_rcv(request_idm, result);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_data_rcv fail %d\n",
-		       __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT;
 	}
 
@@ -94,13 +87,8 @@ int nvme_idm_async_get_result(uint64_t handle, int *result)
 	//          Especially as compared to what the SCSI code does.
 	//          Talk to Tom.
 	if (*result < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: previous async cmd fail result=%d",
 		            __func__, *result);
-		#else
-		printf("%s: previous async cmd fail: result=%d\n",
-		       __func__, *result);
-		#endif //COMPILE_STANDALONE
 	}
 
 EXIT:
@@ -136,43 +124,25 @@ int nvme_idm_async_get_result_lock_count(uint64_t handle, int *count,
 
 	ret = nvme_idm_async_data_rcv(request_idm, result);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	if (*result < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: previous async cmd fail: result=%d",
 		            __func__, *result);
-		#else
-		printf("%s: previous async cmd fail: result=%d\n",
-		       __func__, *result);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_lock_count(request_idm, count, self);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_lock_count fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_lock_count fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: lock_count=%d, self_count=%d",
 	            __func__, *count, *self);
-	#else
-	printf("%s: found: lock_count=%d, self_count=%d\n",
-	       __func__, *count, *self);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -205,41 +175,23 @@ int nvme_idm_async_get_result_lock_mode(uint64_t handle, int *mode,
 
 	ret = nvme_idm_async_data_rcv(request_idm, result);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
-		goto EXIT_FAIL;
 	}
 
 	if (*result < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: previous async cmd fail: result=%d",
 		            __func__, *result);
-		#else
-		printf("%s: previous async cmd fail: result=%d\n",
-		       __func__, *result);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_lock_mode(request_idm, mode);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_lock_mode fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_lock_mode fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: mode=%d", __func__, *mode);
-	#else
-	printf("%s: found: mode=%d\n", __func__, *mode);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -275,39 +227,24 @@ int nvme_idm_async_get_result_lvb(uint64_t handle, char *lvb, int lvb_size,
 
 	ret = nvme_idm_async_data_rcv(request_idm, result);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_data_rcv fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_data_rcv fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	if (*result < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: previous async cmd fail: result=%d",
 		            __func__, *result);
-		#else
-		printf("%s: previous async cmd fail: result=%d\n",
-		       __func__, *result);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_lvb(request_idm, lvb, lvb_size);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_lvb fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_lvb fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_array_dbg(" found: lvb", lvb, lvb_size);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -338,21 +275,13 @@ int nvme_idm_async_lock(char *lock_id, int mode, char *host_id,
 
 	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -392,21 +321,13 @@ int nvme_idm_async_lock_break(char *lock_id, int mode, char *host_id,
 	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
 	                       &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock_break fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock_break fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -463,21 +384,13 @@ int nvme_idm_async_lock_destroy(char *lock_id, int mode, char *host_id,
 
 	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock_destroy fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock_destroy fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -516,21 +429,13 @@ int nvme_idm_async_lock_refresh(char *lock_id, int mode, char *host_id,
 	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
 	                         &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock_refresh fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock_refresh fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -589,22 +494,14 @@ int nvme_idm_async_read_lock_count(char *lock_id, char *host_id, char *drive,
 	ret = _init_read_lock_count(ASYNC_ON, lock_id, host_id, drive,
 					&request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_lock_count fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _init_read_lock_count fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -637,21 +534,13 @@ int nvme_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle)
 
 	ret = _init_read_lock_mode(ASYNC_ON, lock_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_lock_mode fail %d", __func__, ret);
-		#else
-		printf("%s: _init_read_lock_mode fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -687,21 +576,13 @@ int nvme_idm_async_read_lvb(char *lock_id, char *host_id, char *drive,
 
 	ret = _init_read_lvb(ASYNC_ON, lock_id, host_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_lvb fail %d", __func__, ret);
-		#else
-		printf("%s: _init_read_lvb fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -740,22 +621,14 @@ int nvme_idm_async_unlock(char *lock_id, int mode, char *host_id,
 	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
 	                   &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_unlock fail %d", __func__, ret);
-		#else
-		printf("%s: _init_unlock fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_async_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_async_write fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: nvme_idm_async_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -811,11 +684,7 @@ int nvme_idm_get_fd(uint64_t handle)
  */
 int nvme_idm_read_version(int *version, char *drive)
 {
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: NOT IMPLEMENTED!!", __func__);
-	#else
-	printf("%s: NOT IMPLEMENTED!!\n", __func__);
-	#endif //COMPILE_STANDALONE
 	return FAILURE;
 }
 
@@ -842,21 +711,13 @@ int nvme_idm_sync_lock(char *lock_id, int mode, char *host_id,
 
 	ret = _init_lock(lock_id, mode, host_id, drive, timeout, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT;
 	}
 
 	ret = nvme_idm_sync_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 	}
 
 EXIT:
@@ -891,21 +752,13 @@ int nvme_idm_sync_lock_break(char *lock_id, int mode, char *host_id,
 	ret = _init_lock_break(lock_id, mode, host_id, drive, timeout,
 	                       &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock_break fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock_break fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT;
 	}
 
 	ret = nvme_idm_sync_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 	}
 
 EXIT:
@@ -954,21 +807,13 @@ int nvme_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id,
 
 	ret = _init_lock_destroy(lock_id, mode, host_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock_destroy fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock_destroy fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT;
 	}
 
 	ret = nvme_idm_sync_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 	}
 
 EXIT:
@@ -1001,21 +846,13 @@ int nvme_idm_sync_lock_refresh(char *lock_id, int mode, char *host_id,
 	ret = _init_lock_refresh(lock_id, mode, host_id, drive, timeout,
 	                         &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_lock_refresh fail %d", __func__, ret);
-		#else
-		printf("%s: _init_lock_refresh fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT;
 	}
 
 	ret = nvme_idm_sync_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 	}
 
 EXIT:
@@ -1071,42 +908,25 @@ int nvme_idm_sync_read_host_state(char *lock_id, char *host_id,
 
 	ret = _init_read_host_state(lock_id, host_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_host_state fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _init_read_host_state fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_sync_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_host_state(request_idm, host_state);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_host_state fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_host_state fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: host_state=0x%X (%d)",
 	            __func__, *host_state, *host_state);
-	#else
-	printf("%s: found: host_state=0x%X (%d)\n",
-	       __func__, *host_state, *host_state);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -1140,12 +960,8 @@ int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
 	ret = _init_read_lock_count(ASYNC_OFF, lock_id, host_id, drive,
 	                            &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_lock_count fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _init_read_lock_count fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -1155,31 +971,18 @@ int nvme_idm_sync_read_lock_count(char *lock_id, char *host_id, int *count,
 
 	ret = nvme_idm_sync_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_lock_count(request_idm, count, self);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_lock_count fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_lock_count fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: lock_count=%d, self_count=%d",
 	            __func__, *count, *self);
-	#else
-	printf("%s: found: lock_count=%d, self_count=%d\n",
-	       __func__, *count, *self);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -1210,11 +1013,7 @@ int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive)
 
 	ret = _init_read_lock_mode(ASYNC_OFF, lock_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_lock_mode fail %d", __func__, ret);
-		#else
-		printf("%s: _init_read_lock_mode fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -1225,29 +1024,17 @@ int nvme_idm_sync_read_lock_mode(char *lock_id, int *mode, char *drive)
 
 	ret = nvme_idm_sync_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_lock_mode(request_idm, mode);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_lock_mode fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_lock_mode fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: mode=%d", __func__, *mode);
-	#else
-	printf("%s: found: mode=%d\n", __func__, *mode);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -1284,11 +1071,7 @@ int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
 
 	ret = _init_read_lvb(ASYNC_OFF, lock_id, host_id, drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_lvb fail %d", __func__, ret);
-		#else
-		printf("%s: _init_read_lvb fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
@@ -1299,27 +1082,17 @@ int nvme_idm_sync_read_lvb(char *lock_id, char *host_id, char *lvb,
 
 	ret = nvme_idm_sync_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_lvb(request_idm, lvb, lvb_size);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_lvb fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_lvb fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_array_dbg(" found: lvb", lvb, lvb_size);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -1353,43 +1126,27 @@ int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
 
 	ret = _init_read_mutex_group(drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_mutex_group fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _init_read_mutex_group fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_sync_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = _parse_mutex_group(request_idm, info_ptr, info_num);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _parse_mutex_group fail %d", __func__, ret);
-		#else
-		printf("%s: _parse_mutex_group fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	//TODO: Keep -OR- Add debug flag??
 	dumpIdmInfoStruct(*info_ptr);
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: info_num=%d", __func__, *info_num);
-	#else
-	printf("%s: found: info_num=%d\n", __func__, *info_num);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -1421,31 +1178,19 @@ int nvme_idm_sync_read_mutex_num(char *drive, unsigned int *mutex_num)
 
 	ret = _init_read_mutex_num(drive, &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_read_mutex_num fail %d", __func__, ret);
-		#else
-		printf("%s: _init_read_mutex_num fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT_FAIL;
 	}
 
 	ret = nvme_idm_sync_read(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_read fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_read fail %d\n", __func__, ret);
-		#endif
 		goto EXIT_FAIL;
 	}
 
 	_parse_mutex_num(request_idm, mutex_num);
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: found: mutex_num=%d", __func__, *mutex_num);
-	#else
-	printf("%s: found: mutex_num=%d\n", __func__, *mutex_num);
-	#endif //COMPILE_STANDALONE
 EXIT_FAIL:
 	_memory_free_idm_request(request_idm);
 	return ret;
@@ -1476,21 +1221,13 @@ int nvme_idm_sync_unlock(char *lock_id, int mode, char *host_id,
 	ret = _init_unlock(lock_id, mode, host_id, lvb, lvb_size, drive,
 	                   &request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _init_unlock fail %d", __func__, ret);
-		#else
-		printf("%s: _init_unlock fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		goto EXIT;
 	}
 
 	ret = nvme_idm_sync_write(request_idm);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_sync_write fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_sync_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 	}
 
 EXIT:
@@ -1523,35 +1260,22 @@ int _init_lock(char *lock_id, int mode, char *host_id, char *drive,
 
 	ret = _validate_input_write(lock_id, mode, host_id, drive);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _validate_input_write fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _validate_input_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _memory_init_idm_request fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _memory_init_idm_request fail %d\n",
-		       __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
 	                          (*request_idm));
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -1587,35 +1311,22 @@ int _init_lock_break(char *lock_id, int mode, char *host_id, char *drive,
 
 	ret = _validate_input_write(lock_id, mode, host_id, drive);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _validate_input_write fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _validate_input_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _memory_init_idm_request fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _memory_init_idm_request fail %d\n",
-		       __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
 	                          (*request_idm));
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -1650,35 +1361,22 @@ int _init_lock_destroy(char *lock_id, int mode, char *host_id, char *drive,
 
 	ret = _validate_input_write(lock_id, mode, host_id, drive);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _validate_input_write fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _validate_input_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _memory_init_idm_request fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _memory_init_idm_request fail %d\n",
-		       __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0,
 	                          (*request_idm));
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -1714,35 +1412,22 @@ int _init_lock_refresh(char *lock_id, int mode, char *host_id, char *drive,
 
 	ret = _validate_input_write(lock_id, mode, host_id, drive);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _validate_input_write fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _validate_input_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _memory_init_idm_request fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _memory_init_idm_request fail %d\n",
-		       __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
 	                          (*request_idm));
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -1889,10 +1574,8 @@ int _init_read_lock_mode(int async_on, char *lock_id, char *drive,
 	unsigned int mutex_num = 0;
 	int ret;
 
-	#ifndef COMPILE_STANDALONE
 	if (ilm_inject_fault_is_hit())
 		return -EIO;
-	#endif //COMPILE_STANDALONE
 
 	if (!lock_id || !drive)
 		return -EINVAL;
@@ -2021,10 +1704,8 @@ int _init_read_mutex_group(char *drive, struct idm_nvme_request **request_idm)
 	unsigned int mutex_num = 0;
 	int ret;
 
-	#ifndef COMPILE_STANDALONE
 	if (ilm_inject_fault_is_hit())
 		return -EIO;
-	#endif //COMPILE_STANDALONE
 
 	if (!drive)
 		return -EINVAL;
@@ -2065,19 +1746,13 @@ int _init_read_mutex_num(char *drive, struct idm_nvme_request **request_idm)
 
 	int ret;
 
-	#ifndef COMPILE_STANDALONE
 	if (ilm_inject_fault_is_hit())
 		return -EIO;
-	#endif //COMPILE_STANDALONE
 
 	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _memory_init_idm_request fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _memory_init_idm_request fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -2121,24 +1796,15 @@ int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
 
 	ret = _validate_input_write(lock_id, mode, host_id, drive);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _validate_input_write fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _validate_input_write fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
 	ret = _memory_init_idm_request(request_idm, DFLT_NUM_IDM_DATA_BLOCKS);
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: _memory_init_idm_request fail %d",
 		            __func__, ret);
-		#else
-		printf("%s: _memory_init_idm_request fail %d\n",
-		       __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -2146,11 +1812,7 @@ int _init_unlock(char *lock_id, int mode, char *host_id, char *lvb,
 	ret = nvme_idm_write_init(lock_id, mode, host_id, drive, 0,
 	                          (*request_idm));
 	if (ret < 0) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: nvme_idm_write_init fail %d", __func__, ret);
-		#else
-		printf("%s: nvme_idm_write_init fail %d\n", __func__, ret);
-		#endif //COMPILE_STANDALONE
 		return ret;
 	}
 
@@ -2220,11 +1882,7 @@ int _memory_init_idm_request(struct idm_nvme_request **request_idm,
 
 	*request_idm = malloc(sizeof(struct idm_nvme_request));
 	if (!request_idm) {
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: request memory allocate fail", __func__);
-		#else
-		printf("%s: request memory allocate fail\n", __func__);
-		#endif //COMPILE_STANDALONE
 		return -ENOMEM;
 	}
 	memset((*request_idm), 0, sizeof(**request_idm));
@@ -2233,11 +1891,7 @@ int _memory_init_idm_request(struct idm_nvme_request **request_idm,
 	(*request_idm)->data_idm = malloc(data_len);
 	if (!(*request_idm)->data_idm) {
 		_memory_free_idm_request((*request_idm));
-		#ifndef COMPILE_STANDALONE
 		ilm_log_err("%s: request data memory allocate fail", __func__);
-		#else
-		printf("%s: request data memory allocate fail\n", __func__);
-		#endif //COMPILE_STANDALONE
 		return -ENOMEM;
 	}
 	memset((*request_idm)->data_idm, 0, data_len);
@@ -2279,23 +1933,11 @@ int _parse_host_state(struct idm_nvme_request *request_idm, int *host_state)
 
 	data_idm = request_idm->data_idm;
 	for (i = 0; i < mutex_num; i++) {
-		#ifndef COMPILE_STANDALONE
 		//TODO: Layout improvement over adhereing to 80 char limit??
 		ilm_log_array_dbg("resource_id",  data_idm[i].resource_id, IDM_LOCK_ID_LEN_BYTES);
 		ilm_log_array_dbg("lock_id",      bswap_lock_id,           IDM_LOCK_ID_LEN_BYTES);
 		ilm_log_array_dbg("data host_id", data_idm[i].host_id,     IDM_HOST_ID_LEN_BYTES);
 		ilm_log_array_dbg("host_id",      bswap_host_id,           IDM_HOST_ID_LEN_BYTES);
-		#else
-		printf("bswap_lock_id    = '");
-		_print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
-		printf("data resource_id = '");
-		_print_char_arr(data_idm[i].resource_id,
-		                IDM_LOCK_ID_LEN_BYTES);
-		printf("bswap_host_id = '");
-		_print_char_arr(bswap_host_id, IDM_HOST_ID_LEN_BYTES);
-		printf("data host_id  = '");
-		_print_char_arr(data_idm[i].host_id, IDM_HOST_ID_LEN_BYTES);
-		#endif //COMPILE_STANDALONE
 
 		/* Skip for other locks */
 		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
@@ -2354,7 +1996,6 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 		if (!locked)
 			continue;
 
-		#ifndef COMPILE_STANDALONE
 		ilm_log_array_dbg("resource_id", data_idm[i].resource_id,
 		                  IDM_LOCK_ID_LEN_BYTES);
 		ilm_log_array_dbg("lock_id", bswap_lock_id,
@@ -2363,17 +2004,6 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 		                  IDM_HOST_ID_LEN_BYTES);
 		ilm_log_array_dbg("host_id", bswap_host_id,
 		                  IDM_HOST_ID_LEN_BYTES);
-		#else
-		printf("bswap_lock_id    = '");
-		_print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
-		printf("data resource_id = '");
-		_print_char_arr(data_idm[i].resource_id,
-		                IDM_LOCK_ID_LEN_BYTES);
-		printf("bswap_host_id = '");
-		_print_char_arr(bswap_host_id, IDM_HOST_ID_LEN_BYTES);
-		printf("data host_id  = '");
-		_print_char_arr(data_idm[i].host_id, IDM_HOST_ID_LEN_BYTES);
-		#endif //COMPILE_STANDALONE
 
 		/* Skip for other locks */
 		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
@@ -2384,12 +2014,8 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 		           IDM_HOST_ID_LEN_BYTES)) {
 			if (*self) {
 				/* Must be wrong if self has been accounted */
-				#ifndef COMPILE_STANDALONE
 				ilm_log_err("%s: account self %d > 1",
 					__func__, *self);
-				#else
-				printf("%s: account self %d > 1\n", __func__, *self);
-				#endif //COMPILE_STANDALONE
 				goto EXIT;
 			}
 			*self = 1;
@@ -2433,18 +2059,10 @@ int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode)
 	data_idm = request_idm->data_idm;
 	for (i = 0; i < mutex_num; i++) {
 
-		#ifndef COMPILE_STANDALONE
 		ilm_log_array_dbg("resource_id", data_idm[i].resource_id,
 		                  IDM_LOCK_ID_LEN_BYTES);
 		ilm_log_array_dbg("lock_id(bswap)", bswap_lock_id,
 		                  IDM_LOCK_ID_LEN_BYTES);
-		#else
-		printf("lock_id(bswap) = '");
-		_print_char_arr(bswap_lock_id, IDM_LOCK_ID_LEN_BYTES);
-		printf("resource_id    = '");
-		_print_char_arr(data_idm[i].resource_id,
-		                IDM_LOCK_ID_LEN_BYTES);
-		#endif //COMPILE_STANDALONE
 
 		/* Skip for other locks */
 		if (memcmp(data_idm[i].resource_id, bswap_lock_id,
@@ -2454,11 +2072,7 @@ int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode)
 		state = __bswap_64(data_idm[i].state);
 		class = __bswap_64(data_idm[i].class);
 
-		#ifndef COMPILE_STANDALONE
 		ilm_log_dbg("%s: state=%lx class=%lx", __func__, state, class);
-		#else
-		printf("%s: state=%lx class=%lx\n", __func__, state, class);
-		#endif //COMPILE_STANDALONE
 
 		if (state == IDM_STATE_UNINIT ||
 		    state == IDM_STATE_UNLOCKED ||
@@ -2469,20 +2083,12 @@ int _parse_lock_mode(struct idm_nvme_request *request_idm, int *mode)
 		} else if (class == IDM_CLASS_SHARED_PROTECTED_READ) {
 			*mode = IDM_MODE_SHAREABLE;
 		} else if (class == IDM_CLASS_PROTECTED_WRITE) {
-			#ifndef COMPILE_STANDALONE
 			ilm_log_err("%s: PROTECTED_WRITE is not unsupported", __func__);
-			#else
-			printf("%s: PROTECTED_WRITE is not unsupported\n", __func__);
-			#endif //COMPILE_STANDALONE
 			ret = -EFAULT;
 			goto EXIT;
 		}
 
-		#ifndef COMPILE_STANDALONE
 		ilm_log_dbg("%s: mode=%d", __func__, *mode);
-		#else
-		printf("%s: mode=%d\n", __func__, *mode);
-		#endif //COMPILE_STANDALONE
 
 		if (*mode == IDM_MODE_EXCLUSIVE || *mode == IDM_MODE_SHAREABLE)
 			break;
@@ -2605,13 +2211,8 @@ int _parse_mutex_group(struct idm_nvme_request *request_idm,
 			info->mode = IDM_MODE_SHAREABLE;
 			break;
 		default:
-			#ifndef COMPILE_STANDALONE
 			ilm_log_err("%s: IDM class is not unsupported %ld",
 			            __func__, class);
-			#else
-			printf("%s: IDM class is not unsupported %ld\n",
-			            __func__, class);
-			#endif //COMPILE_STANDALONE
 			ret = -EFAULT;
 			goto EXIT;
 		}
@@ -2685,13 +2286,8 @@ void _parse_mutex_num(struct idm_nvme_request *request_idm,
 	*mutex_num = ((data[1]) & 0xff);
 	*mutex_num |= ((data[0]) & 0xff) << 8;
 
-	#ifndef COMPILE_STANDALONE
 	ilm_log_dbg("%s: data[0]=%u data[1]=%u mutex mutex_num=%u",
 	            __func__, data[0], data[1], *mutex_num);
-	#else
-	printf("%s: data[0]=%u data[1]=%u mutex mutex_num=%u\n",
-	       __func__, data[0], data[1], *mutex_num);
-	#endif //COMPILE_STANDALONE
 }
 
 /**
@@ -2710,10 +2306,8 @@ int _validate_input_common(char *lock_id, char *host_id, char *drive)
 	printf("%s: START\n", __func__);
 	#endif //FUNCTION_ENTRY_DEBUG
 
-	#ifndef COMPILE_STANDALONE
 	if (ilm_inject_fault_is_hit())
 		return -EIO;
-	#endif //COMPILE_STANDALONE
 
 	if (!lock_id || !host_id || !drive)
 		return -EINVAL;

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -30,6 +30,9 @@ Setup to be gcc-defined (-D) in make file */
 /* Define for logging a function's name each time it is entered. */
 #define DBG__LOG_FUNC_ENTRY
 
+/* Defines for logging struct field data for important data structs */
+#define DBG__DUMP_STRUCTS
+
 ////////////////////////////////////////////////////////////////////////////////
 // INCLUDES
 ////////////////////////////////////////////////////////////////////////////////
@@ -1156,8 +1159,9 @@ int nvme_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr,
 		goto EXIT_FAIL;
 	}
 
-	//TODO: Keep -OR- Add debug flag??
+	#ifdef DBG__DUMP_STRUCTS
 	dumpIdmInfoStruct(*info_ptr);
+	#endif
 
 	ilm_log_dbg("%s: found: info_num=%d", __func__, *info_num);
 EXIT_FAIL:

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -23,13 +23,16 @@
 #include "idm_nvme_api.h"
 #include "idm_nvme_io.h"
 #include "idm_nvme_utils.h"
+#include "inject_fault.h"
+#include "log.h"
+#include "util.h"
 
 
 //////////////////////////////////////////
 // COMPILE FLAGS
 //////////////////////////////////////////
 //TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER NVME FILES COMPILE WITH THE REST OF PROPELLER.
-#define COMPILE_STANDALONE
+// #define COMPILE_STANDALONE
 #ifdef MAIN_ACTIVATE_NVME_API
 #define MAIN_ACTIVATE_NVME_API 1
 #else
@@ -811,7 +814,7 @@ int nvme_idm_get_fd(uint64_t handle)
 int nvme_idm_read_version(int *version, char *drive)
 {
 	#ifndef COMPILE_STANDALONE
-	ilm_log_dbg("%s: NOT IMPLEMENTED!!", __func__,);
+	ilm_log_dbg("%s: NOT IMPLEMENTED!!", __func__);
 	#else
 	printf("%s: NOT IMPLEMENTED!!\n", __func__);
 	#endif //COMPILE_STANDALONE

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2010-2011 Red Hat, Inc.
- * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2023 Seagate Technology LLC and/or its Affiliates.
  *
  * idm_nvme_io.c - Contains the lowest-level function that allow the IDM In-drive Mutex (IDM)
  *                  to talk to the Linux kernel (via ioctl(), read() or write())
@@ -53,10 +53,12 @@
 //////////////////////////////////////////
 // COMPILE FLAGS
 //////////////////////////////////////////
-#ifdef MAIN_ACTIVATE_NVME_IO
-#define MAIN_ACTIVATE_NVME_IO 1
+/* For using internal main() for stand-alone debug compilation.
+Setup to be gcc-defined (-D) in make file */
+#ifdef DBG__NVME_IO_MAIN_ENABLE
+#define DBG__NVME_IO_MAIN_ENABLE 1
 #else
-#define MAIN_ACTIVATE_NVME_IO 0
+#define DBG__NVME_IO_MAIN_ENABLE 0
 #endif
 
 /* Define for logging a function's name each time it is entered. */
@@ -681,7 +683,7 @@ int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 
 
 
-#if MAIN_ACTIVATE_NVME_IO
+#if DBG__NVME_IO_MAIN_ENABLE
 /*#########################################################################################
 ########################### STAND-ALONE MAIN ##############################################
 #########################################################################################*/
@@ -727,4 +729,4 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-#endif//MAIN_ACTIVATE_NVME_IO
+#endif//DBG__NVME_IO_MAIN_ENABLE

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -47,6 +47,9 @@ Setup to be gcc-defined (-D) in make file */
 /* Define for logging a function's name each time it is entered. */
 #define DBG__LOG_FUNC_ENTRY
 
+/* Defines for logging struct field data for important data structs */
+#define DBG__DUMP_STRUCTS
+
 ////////////////////////////////////////////////////////////////////////////////
 // INCLUDES
 ////////////////////////////////////////////////////////////////////////////////
@@ -286,8 +289,9 @@ int nvme_idm_sync_read(struct idm_nvme_request *request_idm)
 	}
 
 	ilm_log_dbg("%s: retrieved struct idm_data", __func__);
-//TODO: Put on debug flag OR remove??
+	#ifdef DBG__DUMP_STRUCTS
 	dumpIdmDataStruct(request_idm->data_idm);
+	#endif
 
 	return ret;
 }
@@ -350,9 +354,10 @@ int _async_idm_cmd_send(struct idm_nvme_request *request_idm)
 	int fd_nvme;
 	int ret = FAILURE;
 
-	//TODO: Put this under a debug flag of some kind??
+	#ifdef DBG__DUMP_STRUCTS
 	dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
 	dumpIdmDataStruct(request_idm->data_idm);
+	#endif
 
 	fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
 	if (fd_nvme < 0) {
@@ -406,8 +411,9 @@ int _async_idm_data_rcv(struct idm_nvme_request *request_idm, int *result)
 
 	*result = _idm_cmd_check_status(result_ani, request_idm->opcode_idm);
 
-	// //TODO: Put this under a debug flag of some kind??
-	// dumpIdmDataStruct(request_idm->data_idm);
+	#ifdef DBG__DUMP_STRUCTS
+	dumpIdmDataStruct(request_idm->data_idm);
+	#endif
 
 	ilm_log_dbg("%s: result found: ani:%d(0x%X), final:%d(0x%X)",
 	       __func__, result_ani, result_ani, *result, *result);
@@ -633,9 +639,10 @@ int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 	int fd_nvme;
 	int ret = FAILURE;
 
-	//TODO: Put this under a debug flag of some kind??
+	#ifdef DBG__DUMP_STRUCTS
 	dumpNvmeCmdStruct(&request_idm->cmd_nvme, 1, 1);
 	dumpIdmDataStruct(request_idm->data_idm);
+	#endif
 
 	memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
@@ -648,8 +655,9 @@ int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 
 	fill_nvme_cmd(request_idm, &cmd_nvme_passthru);
 
-	//TODO: Keep?  Add debug flag?
+	#ifdef DBG__DUMP_STRUCTS
 	dumpNvmePassthruCmd(&cmd_nvme_passthru);
+	#endif
 
 	//ioctl()'s return value comes from:
 	//  NVMe Completion Queue Entry (CQE) DWORD3:

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -46,13 +46,15 @@
 
 #include "idm_nvme_io.h"
 #include "idm_nvme_utils.h"
+#include "log.h"
+#include "util.h"
 
 
 //////////////////////////////////////////
 // COMPILE FLAGS
 //////////////////////////////////////////
 //TODO: DELETE THESE 2 (AND ALL CORRESPONDING CODE) AFTER NVME FILES COMPILE WITH THE REST OF PROPELLER.
-#define COMPILE_STANDALONE
+// #define COMPILE_STANDALONE
 #ifdef MAIN_ACTIVATE_NVME_IO
 #define MAIN_ACTIVATE_NVME_IO 1
 #else

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -59,7 +59,8 @@
 #define MAIN_ACTIVATE_NVME_IO 0
 #endif
 
-#define FUNCTION_ENTRY_DEBUG    //TODO: Remove this entirely???
+/* Define for logging a function's name each time it is entered. */
+#define DBG__LOG_FUNC_ENTRY
 
 
 //////////////////////////////////////////
@@ -79,9 +80,9 @@
  */
 int nvme_idm_async_data_rcv(struct idm_nvme_request *request_idm, int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -110,9 +111,9 @@ int nvme_idm_async_data_rcv(struct idm_nvme_request *request_idm, int *result)
  */
 int nvme_idm_async_read(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -150,9 +151,9 @@ int nvme_idm_async_read(struct idm_nvme_request *request_idm)
  */
 int nvme_idm_async_write(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -187,9 +188,9 @@ int nvme_idm_async_write(struct idm_nvme_request *request_idm)
  */
 void nvme_idm_read_init(char *drive, struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	request_idm->opcode_idm = IDM_OPCODE_INIT;  //Ignored, but default for all idm reads.
 	strncpy(request_idm->drive, drive, PATH_MAX);
@@ -215,9 +216,9 @@ void nvme_idm_read_init(char *drive, struct idm_nvme_request *request_idm)
 int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
                         uint64_t timeout, struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	//Cache the input params
 //TODO: memcpy() -OR- strncpy() HERE?? (and everywhere else for that matter)
@@ -260,9 +261,9 @@ int nvme_idm_write_init(char *lock_id, int mode, char *host_id, char *drive,
  */
 int nvme_idm_sync_read(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -302,9 +303,9 @@ int nvme_idm_sync_read(struct idm_nvme_request *request_idm)
  */
 int nvme_idm_sync_write(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int ret;
 
@@ -339,9 +340,9 @@ int nvme_idm_sync_write(struct idm_nvme_request *request_idm)
  */
 int _async_idm_cmd_send(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int fd_nvme;
 	int ret = FAILURE;
@@ -381,9 +382,9 @@ EXIT:
  */
 int _async_idm_data_rcv(struct idm_nvme_request *request_idm, int *result)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	int result_ani;
 	int ret;
@@ -424,9 +425,9 @@ EXIT:
  */
 int _idm_cmd_check_status(int status, uint8_t opcode_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	uint16_t sct, sc;   // status code type, status code
 	int ret;
@@ -538,9 +539,9 @@ int _idm_cmd_check_status(int status, uint8_t opcode_idm)
  */
 int _idm_cmd_init(struct idm_nvme_request *request_idm, uint8_t opcode_nvme)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct nvme_idm_vendor_cmd *cmd_nvme = &request_idm->cmd_nvme;
 
@@ -566,9 +567,9 @@ int _idm_cmd_init(struct idm_nvme_request *request_idm, uint8_t opcode_nvme)
  */
 int _idm_data_init_wrt(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct idm_data *data_idm = request_idm->data_idm;
 
@@ -621,9 +622,9 @@ int _idm_data_init_wrt(struct idm_nvme_request *request_idm)
  */
 int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 {
-	#ifdef FUNCTION_ENTRY_DEBUG
-	printf("%s: START\n", __func__);
-	#endif //FUNCTION_ENTRY_DEBUG
+	#ifdef DBG__LOG_FUNC_ENTRY
+	ilm_log_dbg("%s: ENTRY", __func__);
+	#endif
 
 	struct nvme_passthru_cmd cmd_nvme_passthru;
 	int fd_nvme;

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -33,6 +33,23 @@
  *
  */
 
+////////////////////////////////////////////////////////////////////////////////
+// COMPILE FLAGS
+////////////////////////////////////////////////////////////////////////////////
+/* For using internal main() for stand-alone debug compilation.
+Setup to be gcc-defined (-D) in make file */
+#ifdef DBG__NVME_IO_MAIN_ENABLE
+#define DBG__NVME_IO_MAIN_ENABLE 1
+#else
+#define DBG__NVME_IO_MAIN_ENABLE 0
+#endif
+
+/* Define for logging a function's name each time it is entered. */
+#define DBG__LOG_FUNC_ENTRY
+
+////////////////////////////////////////////////////////////////////////////////
+// INCLUDES
+////////////////////////////////////////////////////////////////////////////////
 #include <byteswap.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -49,25 +66,9 @@
 #include "log.h"
 #include "util.h"
 
-
-//////////////////////////////////////////
-// COMPILE FLAGS
-//////////////////////////////////////////
-/* For using internal main() for stand-alone debug compilation.
-Setup to be gcc-defined (-D) in make file */
-#ifdef DBG__NVME_IO_MAIN_ENABLE
-#define DBG__NVME_IO_MAIN_ENABLE 1
-#else
-#define DBG__NVME_IO_MAIN_ENABLE 0
-#endif
-
-/* Define for logging a function's name each time it is entered. */
-#define DBG__LOG_FUNC_ENTRY
-
-
-//////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 // FUNCTIONS
-//////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 /**
  * nvme_idm_async_data_rcv - Asynchronously retrieves the status word and
@@ -679,14 +680,10 @@ int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 	return ret;
 }
 
-
-
-
-
+////////////////////////////////////////////////////////////////////////////////
+// DEBUG MAIN
+////////////////////////////////////////////////////////////////////////////////
 #if DBG__NVME_IO_MAIN_ENABLE
-/*#########################################################################################
-########################### STAND-ALONE MAIN ##############################################
-#########################################################################################*/
 #define DRIVE_DEFAULT_DEVICE "/dev/nvme0n1";
 
 //To compile:

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -26,6 +26,7 @@
  */
 void dumpIdmDataStruct(struct idm_data *d)
 {
+	ilm_log_dbg("=======================");
 	ilm_log_dbg("struct idm_data: fields");
 	ilm_log_dbg("=======================");
 	ilm_log_dbg("state\\ignored0     = 0x%.16"PRIX64" (%lu)", d->state,    d->state);
@@ -48,6 +49,7 @@ void dumpIdmDataStruct(struct idm_data *d)
  */
 void dumpIdmInfoStruct(struct idm_info *info)
 {
+	ilm_log_dbg("======================");
 	ilm_log_dbg("struct idm_info: fields");
 	ilm_log_dbg("======================");
 	ilm_log_array_dbg("id", info->id, IDM_LOCK_ID_LEN_BYTES);
@@ -73,6 +75,7 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 	if(view_fields){
 		struct nvme_idm_vendor_cmd *c = cmd_nvme;
 
+		ilm_log_dbg("===========================");
 		ilm_log_dbg("struct nvme_idm_vendor_cmd: fields");
 		ilm_log_dbg("===========================");
 		ilm_log_dbg("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)", c->opcode_nvme,  c->opcode_nvme);
@@ -102,10 +105,11 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 		uint32_t *cdw = (uint32_t*)cmd_nvme;
 		int i;
 
+		ilm_log_dbg("===============================");
 		ilm_log_dbg("struct nvme_idm_vendor_cmd: CDWs (hex)");
 		ilm_log_dbg("===============================");
 		for(i = 0; i <= 17; i++) {
-			ilm_log_dbg("cdw%.2d = 0x%.8X\n", i, cdw[i]);
+			ilm_log_dbg("cdw%.2d = 0x%.8X", i, cdw[i]);
 		}
 		ilm_log_dbg("\n");
 	}
@@ -113,7 +117,7 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 
 void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd)
 {
-	ilm_log_dbg("\n");
+	ilm_log_dbg("================================");
 	ilm_log_dbg("struct nvme_passthru_cmd: fields");
 	ilm_log_dbg("================================");
 	ilm_log_dbg("opcode       (CDW0[ 7:0])  = 0x%.2X (%u)", cmd->opcode,       cmd->opcode);
@@ -155,7 +159,7 @@ void fill_nvme_cmd(struct idm_nvme_request *request_idm,
 	// request_idm->cmd_nvme.nsid = ioctl(fd_nvme, NVME_IOCTL_ID);
 	// if (request_idm->cmd_nvme.nsid <= 0)
 	// {
-	//     ilm_log_dbg("%s: nsid ioctl fail: %d\n", __func__, request_idm->cmd_nvme.nsid);
+	//     ilm_log_dbg("%s: nsid ioctl fail: %d", __func__, request_idm->cmd_nvme.nsid);
 	//     ret = request_idm->cmd_nvme.nsid;
 	//     goto EXIT;
 	// }

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2010-2011 Red Hat, Inc.
- * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2023 Seagate Technology LLC and/or its Affiliates.
  *
  * idm_nvme_utils.c - Contains nvme-related helper utility functions.
  *
@@ -14,8 +14,9 @@
 #include <stdio.h>
 
 #include "idm_nvme_utils.h"
+#include "log.h"
 
-//TODO: switch all "printf" to appropriate log functions from this project's log.h
+//TODO: switch all "ilm_log_dbg" to appropriate log functions from this project's log.h
 
 /**
  * dumpIdmDataStruct - Convenience function for pretty printing the contends of
@@ -25,22 +26,18 @@
  */
 void dumpIdmDataStruct(struct idm_data *d)
 {
-	printf("struct idm_data: fields\n");
-	printf("=======================\n");
-	printf("state\\ignored0     = 0x%.16"PRIX64" (%lu)\n", d->state,    d->state);
-	printf("modified\\time_now  = 0x%.16"PRIX64" (%lu)\n", d->modified, d->modified);
-	printf("countdown          = 0x%.16"PRIX64" (%lu)\n", d->countdown, d->countdown);
-	printf("class              = 0x%.16"PRIX64" (%lu)\n", d->class,     d->class);
-	printf("resource_ver = '");
-	_print_char_arr(d->resource_ver, IDM_LVB_LEN_BYTES);
-	printf("res_ver_type = 0x%X\n", d->resource_ver[0]);
-	printf("resource_id = '");
-	_print_char_arr(d->resource_id, IDM_LOCK_ID_LEN_BYTES);
-	printf("metadata    = '");
-	_print_char_arr(d->metadata, IDM_DATA_METADATA_LEN_BYTES);
-	printf("host_id     = '");
-	_print_char_arr(d->host_id, IDM_HOST_ID_LEN_BYTES);
-	printf("\n");
+	ilm_log_dbg("struct idm_data: fields");
+	ilm_log_dbg("=======================");
+	ilm_log_dbg("state\\ignored0     = 0x%.16"PRIX64" (%lu)", d->state,    d->state);
+	ilm_log_dbg("modified\\time_now  = 0x%.16"PRIX64" (%lu)", d->modified, d->modified);
+	ilm_log_dbg("countdown          = 0x%.16"PRIX64" (%lu)", d->countdown, d->countdown);
+	ilm_log_dbg("class              = 0x%.16"PRIX64" (%lu)", d->class,     d->class);
+	ilm_log_array_dbg("resource_ver", d->resource_ver, IDM_LVB_LEN_BYTES);
+	ilm_log_dbg("res_ver_type = 0x%X", d->resource_ver[0]);
+	ilm_log_array_dbg("resource_id", d->resource_id, IDM_LOCK_ID_LEN_BYTES);
+	ilm_log_array_dbg("metadata", d->metadata, IDM_DATA_METADATA_LEN_BYTES);
+	ilm_log_array_dbg("host_id", d->host_id, IDM_HOST_ID_LEN_BYTES);
+	ilm_log_dbg("\n");
 }
 
 /**
@@ -51,17 +48,15 @@ void dumpIdmDataStruct(struct idm_data *d)
  */
 void dumpIdmInfoStruct(struct idm_info *info)
 {
-	printf("struct idm_info: fields\n");
-	printf("======================\n");
-	printf("id      = '");
-	_print_char_arr(info->id, IDM_LOCK_ID_LEN_BYTES);
-	printf("state   = 0x%X (%d)\n", info->state, info->state);
-	printf("mode    = 0x%X (%d)\n", info->mode, info->mode);
-	printf("host_id = '");
-	_print_char_arr(info->host_id, IDM_HOST_ID_LEN_BYTES);
-	printf("last_renew_time  = 0x%.16"PRIX64" (%lu)\n", info->last_renew_time,
+	ilm_log_dbg("struct idm_info: fields");
+	ilm_log_dbg("======================");
+	ilm_log_array_dbg("id", info->id, IDM_LOCK_ID_LEN_BYTES);
+	ilm_log_dbg("state   = 0x%X (%d)", info->state, info->state);
+	ilm_log_dbg("mode    = 0x%X (%d)", info->mode, info->mode);
+	ilm_log_array_dbg("host_id", info->host_id, IDM_HOST_ID_LEN_BYTES);
+	ilm_log_dbg("last_renew_time  = 0x%.16"PRIX64" (%lu)", info->last_renew_time,
 	                                                    info->last_renew_time);
-	printf("\n");
+	ilm_log_dbg("\n");
 }
 
 /**
@@ -78,80 +73,68 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 	if(view_fields){
 		struct nvme_idm_vendor_cmd *c = cmd_nvme;
 
-		printf("struct nvme_idm_vendor_cmd: fields\n");
-		printf("===========================\n");
-		printf("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)\n", c->opcode_nvme,  c->opcode_nvme);
-		printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", c->flags,        c->flags);
-		printf("command_id   (CDW0[32:16]) = 0x%.4X (%u)\n", c->command_id,   c->command_id);
-		printf("nsid         (CDW1[32:0])  = 0x%.8X (%u)\n", c->nsid,         c->nsid);
-		printf("cdw2         (CDW2[32:0])  = 0x%.8X (%u)\n", c->cdw2,         c->cdw2);
-		printf("cdw3         (CDW3[32:0])  = 0x%.8X (%u)\n", c->cdw3,         c->cdw3);
-		printf("metadata     (CDW5&4[64:0])= 0x%.16"PRIX64" (%lu)\n",c->metadata, c->metadata);
-		printf("addr         (CDW7&6[64:0])= 0x%.16"PRIX64" (%lu)\n",c->addr, c->addr);
-		printf("metadata_len (CDW8[32:0])  = 0x%.8X (%u)\n", c->metadata_len, c->metadata_len);
-		printf("data_len     (CDW9[32:0])  = 0x%.8X (%u)\n", c->data_len,     c->data_len);
-		printf("ndt          (CDW10[32:0]) = 0x%.8X (%u)\n", c->ndt,          c->ndt);
-		printf("ndm          (CDW11[32:0]) = 0x%.8X (%u)\n", c->ndm,          c->ndm);
-		printf("opcode_idm_bits7_4(CDW12[ 7:0]) = 0x%.2X (%u)\n", c->opcode_idm_bits7_4, c->opcode_idm_bits7_4);
-		printf("group_idm    (CDW12[15:8]) = 0x%.2X (%u)\n", c->group_idm,    c->group_idm);
-		printf("rsvd2        (CDW12[32:16])= 0x%.4X (%u)\n", c->rsvd2,        c->rsvd2);
-		printf("cdw13        (CDW13[32:0]) = 0x%.8X (%u)\n", c->cdw13,        c->cdw13);
-		printf("cdw14        (CDW14[32:0]) = 0x%.8X (%u)\n", c->cdw14,        c->cdw14);
-		printf("cdw15        (CDW15[32:0]) = 0x%.8X (%u)\n", c->cdw15,        c->cdw15);
-		printf("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)\n", c->timeout_ms,   c->timeout_ms);
-		printf("result       (CDW17[32:0]) = 0x%.8X (%u)\n", c->result,       c->result);
-		printf("\n");
+		ilm_log_dbg("struct nvme_idm_vendor_cmd: fields");
+		ilm_log_dbg("===========================");
+		ilm_log_dbg("opcode_nvme  (CDW0[ 7:0])  = 0x%.2X (%u)", c->opcode_nvme,  c->opcode_nvme);
+		ilm_log_dbg("flags        (CDW0[15:8])  = 0x%.2X (%u)", c->flags,        c->flags);
+		ilm_log_dbg("command_id   (CDW0[32:16]) = 0x%.4X (%u)", c->command_id,   c->command_id);
+		ilm_log_dbg("nsid         (CDW1[32:0])  = 0x%.8X (%u)", c->nsid,         c->nsid);
+		ilm_log_dbg("cdw2         (CDW2[32:0])  = 0x%.8X (%u)", c->cdw2,         c->cdw2);
+		ilm_log_dbg("cdw3         (CDW3[32:0])  = 0x%.8X (%u)", c->cdw3,         c->cdw3);
+		ilm_log_dbg("metadata     (CDW5&4[64:0])= 0x%.16"PRIX64" (%lu)",c->metadata, c->metadata);
+		ilm_log_dbg("addr         (CDW7&6[64:0])= 0x%.16"PRIX64" (%lu)",c->addr, c->addr);
+		ilm_log_dbg("metadata_len (CDW8[32:0])  = 0x%.8X (%u)", c->metadata_len, c->metadata_len);
+		ilm_log_dbg("data_len     (CDW9[32:0])  = 0x%.8X (%u)", c->data_len,     c->data_len);
+		ilm_log_dbg("ndt          (CDW10[32:0]) = 0x%.8X (%u)", c->ndt,          c->ndt);
+		ilm_log_dbg("ndm          (CDW11[32:0]) = 0x%.8X (%u)", c->ndm,          c->ndm);
+		ilm_log_dbg("opcode_idm_bits7_4(CDW12[ 7:0]) = 0x%.2X (%u)", c->opcode_idm_bits7_4, c->opcode_idm_bits7_4);
+		ilm_log_dbg("group_idm    (CDW12[15:8]) = 0x%.2X (%u)", c->group_idm,    c->group_idm);
+		ilm_log_dbg("rsvd2        (CDW12[32:16])= 0x%.4X (%u)", c->rsvd2,        c->rsvd2);
+		ilm_log_dbg("cdw13        (CDW13[32:0]) = 0x%.8X (%u)", c->cdw13,        c->cdw13);
+		ilm_log_dbg("cdw14        (CDW14[32:0]) = 0x%.8X (%u)", c->cdw14,        c->cdw14);
+		ilm_log_dbg("cdw15        (CDW15[32:0]) = 0x%.8X (%u)", c->cdw15,        c->cdw15);
+		ilm_log_dbg("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)", c->timeout_ms,   c->timeout_ms);
+		ilm_log_dbg("result       (CDW17[32:0]) = 0x%.8X (%u)", c->result,       c->result);
+		ilm_log_dbg("\n");
 	}
 
 	if(view_cdws){
 		uint32_t *cdw = (uint32_t*)cmd_nvme;
 		int i;
 
-		printf("struct nvme_idm_vendor_cmd: CDWs (hex)\n");
-		printf("===============================\n");
+		ilm_log_dbg("struct nvme_idm_vendor_cmd: CDWs (hex)");
+		ilm_log_dbg("===============================");
 		for(i = 0; i <= 17; i++) {
-			printf("cdw%.2d = 0x%.8X\n", i, cdw[i]);
+			ilm_log_dbg("cdw%.2d = 0x%.8X\n", i, cdw[i]);
 		}
-		printf("\n");
+		ilm_log_dbg("\n");
 	}
 }
 
 void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd)
 {
-	printf("\n");
-	printf("struct nvme_passthru_cmd: fields\n");
-	printf("================================\n");
-	printf("opcode       (CDW0[ 7:0])  = 0x%.2X (%u)\n", cmd->opcode,       cmd->opcode);
-	printf("flags        (CDW0[15:8])  = 0x%.2X (%u)\n", cmd->flags,        cmd->flags);
-	printf("rsvd1        (CDW0[32:16]) = 0x%.4X (%u)\n", cmd->rsvd1,        cmd->rsvd1);
-	printf("nsid         (CDW1[32:0])  = 0x%.8X (%u)\n", cmd->nsid,         cmd->nsid);
-	printf("cdw2         (CDW2[32:0])  = 0x%.8X (%u)\n", cmd->cdw2,         cmd->cdw2);
-	printf("cdw3         (CDW3[32:0])  = 0x%.8X (%u)\n", cmd->cdw3,         cmd->cdw3);
-	printf("metadata     (CDW5&4[64:0])= 0x%.16llX (%llu)\n",cmd->metadata, cmd->metadata);
-	printf("addr         (CDW7&6[64:0])= 0x%.16llX (%llu)\n",cmd->addr,     cmd->addr);
-	printf("metadata_len (CDW8[32:0])  = 0x%.8X (%u)\n", cmd->metadata_len, cmd->metadata_len);
-	printf("data_len     (CDW9[32:0])  = 0x%.8X (%u)\n", cmd->data_len,     cmd->data_len);
-	printf("cdw10        (CDW10[32:0]) = 0x%.8X (%u)\n", cmd->cdw10,        cmd->cdw10);
-	printf("cdw11        (CDW11[32:0]) = 0x%.8X (%u)\n", cmd->cdw11,        cmd->cdw11);
-	printf("cdw12        (CDW12[32:0]) = 0x%.8X (%u)\n", cmd->cdw12,        cmd->cdw12);
-	printf("cdw13        (CDW13[32:0]) = 0x%.8X (%u)\n", cmd->cdw13,        cmd->cdw13);
-	printf("cdw14        (CDW14[32:0]) = 0x%.8X (%u)\n", cmd->cdw14,        cmd->cdw14);
-	printf("cdw15        (CDW15[32:0]) = 0x%.8X (%u)\n", cmd->cdw15,        cmd->cdw15);
-	printf("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)\n", cmd->timeout_ms,   cmd->timeout_ms);
-	printf("result       (CDW17[32:0]) = 0x%.8X (%u)\n", cmd->result,       cmd->result);
-	printf("\n");
-}
-
-void _print_char_arr(char *data, unsigned int len)
-{
-	int i;
-	for(i=0; i<len; i++) {
-		if(data[i])
-			printf("%c", data[i]);
-		else
-			printf(" ");
-	}
-	printf("'\n");
+	ilm_log_dbg("\n");
+	ilm_log_dbg("struct nvme_passthru_cmd: fields");
+	ilm_log_dbg("================================");
+	ilm_log_dbg("opcode       (CDW0[ 7:0])  = 0x%.2X (%u)", cmd->opcode,       cmd->opcode);
+	ilm_log_dbg("flags        (CDW0[15:8])  = 0x%.2X (%u)", cmd->flags,        cmd->flags);
+	ilm_log_dbg("rsvd1        (CDW0[32:16]) = 0x%.4X (%u)", cmd->rsvd1,        cmd->rsvd1);
+	ilm_log_dbg("nsid         (CDW1[32:0])  = 0x%.8X (%u)", cmd->nsid,         cmd->nsid);
+	ilm_log_dbg("cdw2         (CDW2[32:0])  = 0x%.8X (%u)", cmd->cdw2,         cmd->cdw2);
+	ilm_log_dbg("cdw3         (CDW3[32:0])  = 0x%.8X (%u)", cmd->cdw3,         cmd->cdw3);
+	ilm_log_dbg("metadata     (CDW5&4[64:0])= 0x%.16llX (%llu)",cmd->metadata, cmd->metadata);
+	ilm_log_dbg("addr         (CDW7&6[64:0])= 0x%.16llX (%llu)",cmd->addr,     cmd->addr);
+	ilm_log_dbg("metadata_len (CDW8[32:0])  = 0x%.8X (%u)", cmd->metadata_len, cmd->metadata_len);
+	ilm_log_dbg("data_len     (CDW9[32:0])  = 0x%.8X (%u)", cmd->data_len,     cmd->data_len);
+	ilm_log_dbg("cdw10        (CDW10[32:0]) = 0x%.8X (%u)", cmd->cdw10,        cmd->cdw10);
+	ilm_log_dbg("cdw11        (CDW11[32:0]) = 0x%.8X (%u)", cmd->cdw11,        cmd->cdw11);
+	ilm_log_dbg("cdw12        (CDW12[32:0]) = 0x%.8X (%u)", cmd->cdw12,        cmd->cdw12);
+	ilm_log_dbg("cdw13        (CDW13[32:0]) = 0x%.8X (%u)", cmd->cdw13,        cmd->cdw13);
+	ilm_log_dbg("cdw14        (CDW14[32:0]) = 0x%.8X (%u)", cmd->cdw14,        cmd->cdw14);
+	ilm_log_dbg("cdw15        (CDW15[32:0]) = 0x%.8X (%u)", cmd->cdw15,        cmd->cdw15);
+	ilm_log_dbg("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)", cmd->timeout_ms,   cmd->timeout_ms);
+	ilm_log_dbg("result       (CDW17[32:0]) = 0x%.8X (%u)", cmd->result,       cmd->result);
+	ilm_log_dbg("\n");
 }
 
 /**
@@ -172,7 +155,7 @@ void fill_nvme_cmd(struct idm_nvme_request *request_idm,
 	// request_idm->cmd_nvme.nsid = ioctl(fd_nvme, NVME_IOCTL_ID);
 	// if (request_idm->cmd_nvme.nsid <= 0)
 	// {
-	//     printf("%s: nsid ioctl fail: %d\n", __func__, request_idm->cmd_nvme.nsid);
+	//     ilm_log_dbg("%s: nsid ioctl fail: %d\n", __func__, request_idm->cmd_nvme.nsid);
 	//     ret = request_idm->cmd_nvme.nsid;
 	//     goto EXIT;
 	// }

--- a/src/idm_nvme_utils.h
+++ b/src/idm_nvme_utils.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /*
  * Copyright (C) 2010-2011 Red Hat, Inc.
- * Copyright (C) 2022 Seagate Technology LLC and/or its Affiliates.
+ * Copyright (C) 2023 Seagate Technology LLC and/or its Affiliates.
  *
  * idm_nvme_utils.h - Contains nvme-related helper utility functions.
   */
@@ -23,5 +23,4 @@ void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd);
 void fill_nvme_cmd(struct idm_nvme_request *request_idm,
                    struct nvme_passthru_cmd *cmd_nvme_passthru);
 
-void _print_char_arr(char *data, unsigned int len);
 #endif /*__IDM_NVME_UTILS_H__ */


### PR DESCRIPTION
Discovered I was handling debug messaging incorrectly.  The pre-existing TEST compile flag allows for use of the ilm_log_...() functions to be used in all cases, so long as the TEST compile flag is used when appropriate.
This PR rips out a bunch of unnecessary code related to re-routing the debug messages to printf() calls.
It also refactors the compile flags used within the NVMe-related code.  
These will probably be ripped out later, but they are useful debug tolls at the moment.
This forced expanded use of the `Makefile.nvme` file, which will remain in the repo as well, for now.
Kept similar `#define` compile flags with separate copies in each file for now, for more usage flexibility.