### PR TITLE
Feature/foss 493 propagate ilm log xxx() calls

### DIFF
--- a/src/ani_api.c
+++ b/src/ani_api.c
@@ -552,7 +552,7 @@ __attribute__ ((unused)) static void table_show(void)
 #define DRIVE3	"/dev/nvme3n1"
 
 int main(void){
-	printf("main\n");
+	printf("main - ani_api\n");
 
 	int ret;
 	struct table_entry* entry;

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2379,6 +2379,8 @@ int _validate_input_write(char *lock_id, int mode, char *host_id, char *drive)
 //gcc idm_nvme_io.c idm_nvme_api.c -o idm_nvme_api
 int main(int argc, char *argv[])
 {
+	printf("main - idm_nvme_api\n");
+
 	char drive[PATH_MAX];
 	int  ret = 0;
 

--- a/src/idm_nvme_utils.c
+++ b/src/idm_nvme_utils.c
@@ -38,7 +38,6 @@ void dumpIdmDataStruct(struct idm_data *d)
 	ilm_log_array_dbg("resource_id", d->resource_id, IDM_LOCK_ID_LEN_BYTES);
 	ilm_log_array_dbg("metadata", d->metadata, IDM_DATA_METADATA_LEN_BYTES);
 	ilm_log_array_dbg("host_id", d->host_id, IDM_HOST_ID_LEN_BYTES);
-	ilm_log_dbg("\n");
 }
 
 /**
@@ -58,7 +57,6 @@ void dumpIdmInfoStruct(struct idm_info *info)
 	ilm_log_array_dbg("host_id", info->host_id, IDM_HOST_ID_LEN_BYTES);
 	ilm_log_dbg("last_renew_time  = 0x%.16"PRIX64" (%lu)", info->last_renew_time,
 	                                                    info->last_renew_time);
-	ilm_log_dbg("\n");
 }
 
 /**
@@ -98,7 +96,6 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 		ilm_log_dbg("cdw15        (CDW15[32:0]) = 0x%.8X (%u)", c->cdw15,        c->cdw15);
 		ilm_log_dbg("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)", c->timeout_ms,   c->timeout_ms);
 		ilm_log_dbg("result       (CDW17[32:0]) = 0x%.8X (%u)", c->result,       c->result);
-		ilm_log_dbg("\n");
 	}
 
 	if(view_cdws){
@@ -111,7 +108,6 @@ void dumpNvmeCmdStruct(struct nvme_idm_vendor_cmd *cmd_nvme, int view_fields,
 		for(i = 0; i <= 17; i++) {
 			ilm_log_dbg("cdw%.2d = 0x%.8X", i, cdw[i]);
 		}
-		ilm_log_dbg("\n");
 	}
 }
 
@@ -138,7 +134,6 @@ void dumpNvmePassthruCmd(struct nvme_passthru_cmd *cmd)
 	ilm_log_dbg("cdw15        (CDW15[32:0]) = 0x%.8X (%u)", cmd->cdw15,        cmd->cdw15);
 	ilm_log_dbg("timeout_ms   (CDW16[32:0]) = 0x%.8X (%u)", cmd->timeout_ms,   cmd->timeout_ms);
 	ilm_log_dbg("result       (CDW17[32:0]) = 0x%.8X (%u)", cmd->result,       cmd->result);
-	ilm_log_dbg("\n");
 }
 
 /**


### PR DESCRIPTION
The PR replaces printf() calls within active code with a call to the appropriate ilm_log_...() function.

There were a couple places where existing printf() calls were ignored:

- in the nvme stand-alone `main()` functions,'
- in the idm_nvme_io_admin file, which will be completely refactored when it's the idm_version command is implemented