### PR TITLE
Feature/foss 541 fix intermittent unit test failures

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -622,16 +622,19 @@ int ilm_scsi_get_part_table_uuid(char *dev, uuid_t *id)
 static void ilm_drive_list_dump(void)
 {
 	struct ilm_hw_drive_node *pos;
-	int i;
+	int i, ver;
+
+	ver = ilm_drive_list_version();
 
 	pthread_mutex_lock(&drive_list_mutex);
 
+	ilm_log_dbg("Device List Version: %d", ver);
 	list_for_each_entry(pos, &drive_list, list) {
-		ilm_log_dbg("Device WWN: 0x%lx", pos->drive.wwn);
+		ilm_log_dbg(" Device WWN: 0x%lx", pos->drive.wwn);
 
 		for (i = 0; i < pos->drive.path_num; i++) {
-			ilm_log_dbg("blk_path %s", pos->drive.path[i].blk_path);
-			ilm_log_dbg("sg_path %s", pos->drive.path[i].sg_path);
+			ilm_log_dbg("  blk_path %s", pos->drive.path[i].blk_path);
+			ilm_log_dbg("  sg_path %s", pos->drive.path[i].sg_path);
 		}
 	}
 

--- a/src/drive.c
+++ b/src/drive.c
@@ -828,7 +828,7 @@ static void *drive_thd_fn(void *arg __maybe_unused)
 	}
 
 	mon = udev_monitor_new_from_netlink(udev, "udev");
-	udev_monitor_filter_add_match_subsystem_devtype(mon, "block", NULL);
+	udev_monitor_filter_add_match_subsystem_devtype(mon, "block", "disk");
 	udev_monitor_enable_receiving(mon);
 	fd = udev_monitor_get_fd(mon);
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,7 +66,7 @@ def ilm_daemon():
 Fixture for manually creating, yielding and then destroying the
 async nvme interface (ANI), which is the custom NVMe IDM async code.
 """
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def idm_async_daemon():
 
     _logger.info("fixture start: idm_async_daemon")
@@ -87,7 +87,7 @@ def idm_async_daemon():
         _logger.error(f'idm_environ_destroy failure:{e}')
         raise e from None
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def idm_sync_daemon():
 
     _logger.info("fixture start: idm_sync_daemon")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -123,14 +123,6 @@ def _init_devices():
 
     _reset_devices()
 
-    LOCK_ID0 ='0000000000000000000000000000000000000000000000000000000000000000'
-    for device in test_devices:
-        try:
-            idm_api.idm_drive_lock_mode(LOCK_ID0, device)
-        except Exception as e:
-            _logger.error(f'{device} read lock mode failure')
-            raise e from None
-
 def _reset_devices():
 
     _logger.info("_reset_devices start")

--- a/test/test_conf.h
+++ b/test/test_conf.h
@@ -6,11 +6,12 @@
  */
 
 //TODO: Consolidate these settings, along with the duplicate python settings, in a .json file
-#define BLK_DEVICE1 "/dev/sd"
-#define BLK_DEVICE2 "/dev/sd"
-#define BLK_DEVICE3 "/dev/sd"
-#define BLK_DEVICE4 "/dev/sd"
-#define BLK_DEVICE5 "/dev/sd"
-#define BLK_DEVICE6 "/dev/sd"
-#define BLK_DEVICE7 "/dev/sd"
-#define BLK_DEVICE8 "/dev/sd"
+#define BLK_DEVICE1 "/dev/sdxxxxx"
+#define BLK_DEVICE2 "/dev/sdxxxxx"
+#define BLK_DEVICE3 "/dev/sdxxxxx"
+#define BLK_DEVICE4 "/dev/sdxxxxx"
+#define BLK_DEVICE5 "/dev/sdxxxxx"
+#define BLK_DEVICE6 "/dev/sdxxxxx"
+#define BLK_DEVICE7 "/dev/sdxxxxx"
+#define BLK_DEVICE8 "/dev/sdxxxxx"
+


### PR DESCRIPTION
The PR contains partial fixes for the intermittent unit test failures.  However, this branch does not fix the main reason for the intermittent unit test failures, which is the excessive udev events that are occurring on NVMe devices.  This branch only addresses fixes that were implemented while trying to debug the cause of the intermittent unit test failures (ie - excessive udev events).
This branch is being merged separately because it contains useful fixes for minimizing the udev event problem and because the udev event issue is likely to be a longer investigation and will therefore be handled on a separate ticket.
Thus far, SCSI devices appeared to not be affected by this issue, just NVMe devices.