### PR TITLE
Feature/foss 542 udev flooding fix

### DIFF
--- a/src/drive.c
+++ b/src/drive.c
@@ -383,7 +383,7 @@ static char *ilm_find_sg_nvme(char *blk_dev)
 {
 	char devs_path[PATH_MAX];
 	char dev_path[PATH_MAX];
-	// int fd;
+        struct stat a_stat;
 	int ret;
 	char *result = NULL;
 
@@ -396,13 +396,12 @@ static char *ilm_find_sg_nvme(char *blk_dev)
 		goto out;
 	}
 
-	// fd = open(dev_path, O_RDWR | O_NONBLOCK);
-	// if (fd < 0) {
-	// 	ilm_log_err("%s: invalid block device %s, fd %d",
-	// 	            __func__, dev_path, fd);
-	// 	goto out;
-	// }
-	// close(fd);
+	if ((stat(dev_path, &a_stat) < 0)) {
+		/* The folder doesn't exist */
+		ilm_log_err("%s: invalid block device path %s",
+		            __func__, dev_path);
+		goto out;
+	}
 
 	result = strdup(dev_path);
 

--- a/src/drive.c
+++ b/src/drive.c
@@ -383,7 +383,7 @@ static char *ilm_find_sg_nvme(char *blk_dev)
 {
 	char devs_path[PATH_MAX];
 	char dev_path[PATH_MAX];
-	int fd;
+	// int fd;
 	int ret;
 	char *result = NULL;
 
@@ -396,13 +396,13 @@ static char *ilm_find_sg_nvme(char *blk_dev)
 		goto out;
 	}
 
-	fd = open(dev_path, O_RDWR | O_NONBLOCK);
-	if (fd < 0) {
-		ilm_log_err("%s: invalid block device %s, fd %d",
-		            __func__, dev_path, fd);
-		goto out;
-	}
-	close(fd);
+	// fd = open(dev_path, O_RDWR | O_NONBLOCK);
+	// if (fd < 0) {
+	// 	ilm_log_err("%s: invalid block device %s, fd %d",
+	// 	            __func__, dev_path, fd);
+	// 	goto out;
+	// }
+	// close(fd);
 
 	result = strdup(dev_path);
 
@@ -828,6 +828,7 @@ static void *drive_thd_fn(void *arg __maybe_unused)
 		ilm_log_err("%s: Can't create udev", __func__);
 		goto out;
 	}
+	ilm_log_err("%s: note: open() removed for nvme", __func__);
 
 	mon = udev_monitor_new_from_netlink(udev, "udev");
 	udev_monitor_filter_add_match_subsystem_devtype(mon, "block", "disk");


### PR DESCRIPTION
The major flooding issue was solved with a minor fix.  
The original intent of using open() on the block path was just to make sure that the drive was present.  Unfortunately, I didn't realize that this action was generating a new udev event.  Replacing the open() with a basic stat() check for folder presence.