### PR TITLE
Feature/foss 545 fix udev event flooding on nvme

### DIFF
--- a/src/idm_api.c
+++ b/src/idm_api.c
@@ -712,7 +712,7 @@ int idm_drive_destroy(char *lock_id, int mode, char *host_id,
 		ret = nvme_idm_sync_lock_destroy(lock_id, mode, host_id,
 		                                 drive);
 	else
-		ret = nvme_idm_sync_lock_destroy(lock_id, mode, host_id,
+		ret = scsi_idm_sync_lock_destroy(lock_id, mode, host_id,
 		                                 drive);
 
 	return ret;
@@ -746,7 +746,7 @@ int idm_drive_get_fd(char *drive, uint64_t handle)
  * The unit tests call directly into the idm_api.so lib.
  * As a result, things like ilm_log... are NOT running and the ANI thread
  * pools are NOT intialized (like they would be at service strtup)
- * This code allows for them to be manually init'ed\destory'ed in the unit
+ * This code allows for them to be manually init'ed\destroy'ed in the unit
  * test environ.  In particluar, the ANI MUST be setup to function properly
  * during async calls.
  *

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -738,14 +738,17 @@ int main(int argc, char *argv[])
             uint64_t    timeout     = 10;
 
             //Create required input structs the IDM API would normally create
-            struct idm_nvme_request *request_idm = NULL;
+            struct idm_nvme_request request_idm;
+	    struct idm_data data;
             int ret = FAILURE;
 
+	    request_idm.data_idm = &data;
+
             ret = nvme_idm_write_init(lock_id, mode, host_id, drive, timeout,
-                                      request_idm);
+                                      &request_idm);
             printf("%s exiting with %d\n", argv[1], ret);
 
-            ret = nvme_idm_sync_write(request_idm);
+            ret = nvme_idm_sync_write(&request_idm);
             printf("%s exiting with %d\n", argv[1], ret);
         }
 

--- a/src/idm_nvme_io.c
+++ b/src/idm_nvme_io.c
@@ -359,7 +359,7 @@ int _async_idm_cmd_send(struct idm_nvme_request *request_idm)
 	dumpIdmDataStruct(request_idm->data_idm);
 	#endif
 
-	fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
+	fd_nvme = open(request_idm->drive, O_RDONLY);
 	if (fd_nvme < 0) {
 		ilm_log_err("%s: error opening drive %s fd %d",
 		            __func__, request_idm->drive, fd_nvme);
@@ -664,7 +664,7 @@ int _sync_idm_cmd_send(struct idm_nvme_request *request_idm)
 
 	memset(&cmd_nvme_passthru, 0, sizeof(struct nvme_passthru_cmd));
 
-	fd_nvme = open(request_idm->drive, O_RDWR | O_NONBLOCK);
+	fd_nvme = open(request_idm->drive, O_RDONLY);
 	if (fd_nvme < 0) {
 		ilm_log_err("%s: error opening drive %s fd %d",
 		            __func__, request_idm->drive, fd_nvme);

--- a/src/idm_nvme_io_admin.c
+++ b/src/idm_nvme_io_admin.c
@@ -89,7 +89,7 @@ int _send_nvme_cmd_admin(char *drive, struct nvme_admin_cmd *cmd_admin)
 	int nvme_fd;
 	int ret;
 
-	if ((nvme_fd = open(drive, O_RDWR | O_NONBLOCK)) < 0) {
+	if ((nvme_fd = open(drive, O_RDONLY)) < 0) {
 		ilm_log_err("%s: error opening drive %s fd %d",
 		            __func__, drive, nvme_fd);
 		return nvme_fd;


### PR DESCRIPTION
When interacting with a NVMe drive, changing the "open() mode" to read-only has silenced the udev events that the "open()" call was previously generating.
Since Propeller is (currently) only using the NVMe Admin Command Set to talk to the drive, this shouldn't be a problem.

strace'd "nvme admin_passthru" and verified that the read-only mode is being used there as well.

A couple random bug fixes discovered along the way