### PR TITLE
Feature/foss 547 logging improvements

### DIFF
--- a/src/idm_cmd_common.h
+++ b/src/idm_cmd_common.h
@@ -47,6 +47,9 @@
 #define IDM_MODE_EXCLUSIVE		1
 #define IDM_MODE_SHAREABLE		2
 
+#define MAX_MUTEX_NUM_WARNING_LIMIT	3500
+#define MAX_MUTEX_NUM_ERROR_LIMIT	3950
+
 //////////////////////////////////////////
 // Enums
 //////////////////////////////////////////

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2368,6 +2368,13 @@ void _parse_mutex_num(struct idm_nvme_request *request_idm,
 
 	ilm_log_dbg("%s: data[0]=%u data[1]=%u mutex mutex_num=%u",
 	            __func__, data[0], data[1], *mutex_num);
+
+	if ((*mutex_num > MAX_MUTEX_NUM_WARNING_LIMIT) && (*mutex_num <= MAX_MUTEX_NUM_ERROR_LIMIT))
+		ilm_log_warn("%s: total mutex_num warning limit exceeded: %d > %d",
+			__func__, *mutex_num, MAX_MUTEX_NUM_WARNING_LIMIT);
+	if (*mutex_num > MAX_MUTEX_NUM_ERROR_LIMIT)
+		ilm_log_err("%s: total mutex_num error limit exceeded: %d > %d",
+			__func__, *mutex_num, MAX_MUTEX_NUM_ERROR_LIMIT);
 }
 
 /**

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2057,7 +2057,6 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 	int                i;
 	uint64_t           state, locked;
 	unsigned int       mutex_num = request_idm->data_num;
-	int                ret       = FAILURE;
 
 	bswap_char_arr(bswap_lock_id, request_idm->lock_id,
 	               IDM_LOCK_ID_LEN_BYTES);
@@ -2092,9 +2091,9 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 		           IDM_HOST_ID_LEN_BYTES)) {
 			if (*self) {
 				/* Must be wrong if self has been accounted */
-				ilm_log_err("%s: account self %d > 1",
-					__func__, *self);
-				goto EXIT;
+				ilm_log_err("%s: duplicate host id (%s) found for lock id (%s) on %s",
+					    __func__, request_idm->host_id, request_idm->lock_id,
+					    request_idm->drive);
 			}
 			*self = 1;
 		}
@@ -2103,9 +2102,7 @@ int _parse_lock_count(struct idm_nvme_request *request_idm, int *count,
 		}
 	}
 
-	ret = SUCCESS;
-EXIT:
-	return ret;
+	return SUCCESS;
 }
 
 /**
@@ -2227,6 +2224,8 @@ int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size)
 		ret = SUCCESS;
 		break;
 	}
+
+	ilm_log_err("%s: lock and host id NOT found: err: %d", __func__, ret);
 
 	return ret;
 }

--- a/src/idm_nvme_api.c
+++ b/src/idm_nvme_api.c
@@ -2225,7 +2225,10 @@ int _parse_lvb(struct idm_nvme_request *request_idm, char *lvb, int lvb_size)
 		break;
 	}
 
-	ilm_log_err("%s: lock and host id NOT found: err: %d", __func__, ret);
+	if (ret)
+		ilm_log_err("%s: lvb not found: host id(%s), lock id(%s) on %s: %d",
+			    __func__, request_idm->host_id, request_idm->lock_id,
+			    request_idm->drive, ret);
 
 	return ret;
 }

--- a/src/idm_scsi.c
+++ b/src/idm_scsi.c
@@ -1615,9 +1615,9 @@ int scsi_idm_sync_read_lock_count(char *lock_id, char *host_id,
 			    IDM_HOST_ID_LEN)) {
 			/* Must be wrong if self has been accounted */
 			if (*self) {
-				ilm_log_err("%s: account self %d > 1",
-					    __func__, *self);
-				goto out;
+				ilm_log_err("%s: duplicate host id (%s) found for lock id (%s) on %s",
+					    __func__, request->host_id, request->lock_id,
+					    request->drive);
 			}
 
 			*self = 1;
@@ -1744,9 +1744,8 @@ int scsi_idm_async_get_result_lock_count(uint64_t handle, int *count, int *self,
 			    IDM_HOST_ID_LEN)) {
 			/* Must be wrong if self has been accounted */
 			if (*self) {
-				ilm_log_err("%s: account self %d > 1",
-					    __func__, *self);
-				goto out;
+				ilm_log_err("%s: duplicate host id (%s) found for lock id (%s) on %s",
+					    __func__, request->host_id, request->lock_id, request->drive);
 			}
 
 			*self = 1;
@@ -1757,7 +1756,6 @@ int scsi_idm_async_get_result_lock_count(uint64_t handle, int *count, int *self,
 
 	*result = ret;
 
-out:
 	free(request->data);
 	free(request);
 	return ret;

--- a/src/idm_scsi.c
+++ b/src/idm_scsi.c
@@ -1315,6 +1315,12 @@ static int scsi_idm_drive_read_mutex_num(char *drive, unsigned int *num)
 	ilm_log_dbg("%s: data[0]=%u data[1]=%u mutex num=%u",
 		    __func__, data[0], data[1], *num);
 
+	if ((*num > MAX_MUTEX_NUM_WARNING_LIMIT) && (*num <= MAX_MUTEX_NUM_ERROR_LIMIT))
+		ilm_log_warn("%s: total mutex_num warning limit exceeded: %d > %d",
+			__func__, *num, MAX_MUTEX_NUM_WARNING_LIMIT);
+	if (*num > MAX_MUTEX_NUM_ERROR_LIMIT)
+		ilm_log_err("%s: total mutex_num error limit exceeded: %d > %d",
+			__func__, *num, MAX_MUTEX_NUM_ERROR_LIMIT);
 out:
 	free(request->data);
 	free(request);

--- a/src/idm_scsi.c
+++ b/src/idm_scsi.c
@@ -1403,6 +1403,10 @@ int scsi_idm_sync_read_lvb(char *lock_id, char *host_id,
 		break;
 	}
 
+	if (ret)
+		ilm_log_err("%s: lvb not found: host id(%s), lock id(%s) on %s: %d",
+			    __func__, request->host_id, request->lock_id,
+			    request->drive, ret);
 out:
 	free(request->data);
 	free(request);


### PR DESCRIPTION
Update and added new log error and warning messages.
Changed control loop when parsing the lock count to make sure that all locks are counted before returning after a bad "self" count (ie self>1) is detected.