### PR TITLE
Feature/foss 551 add destroy to unlocks

### DIFF
--- a/python/idm_api.i
+++ b/python/idm_api.i
@@ -77,7 +77,8 @@ int idm_drive_lock_mode(char *lock_id, int *mode, char *drive);
 int idm_drive_lock_mode_async(char *lock_id, char *drive, uint64_t *handle);
 int idm_drive_lock_mode_async_result(char *drive, uint64_t handle, int *mode, int *result);
 int idm_drive_read_group(char *drive, struct idm_info **info_ptr, int *info_num);
-int idm_drive_destroy(char *lock_id, char *drive);
+int idm_drive_destroy_lock(char *lock_id, int mode, char *host_id, char *drive);
+int idm_drive_destroy_lock_async(char *lock_id, int mode, char *host_id, char *drive, uint64_t *handle);
 
 int idm_drive_async_result(char *drive, uint64_t handle, int *result);
 
@@ -155,7 +156,8 @@ int idm_drive_lock_mode(char *lock_id, int *mode, char *drive);
 int idm_drive_lock_mode_async(char *lock_id, char *drive, uint64_t *handle);
 int idm_drive_lock_mode_async_result(char *drive, uint64_t handle, int *mode, int *result);
 int idm_drive_read_group(char *drive, struct idm_info **info_ptr, int *info_num);
-int idm_drive_destroy(char *lock_id, char *drive);
+int idm_drive_destroy_lock(char *lock_id, int mode, char *host_id, char *drive);
+int idm_drive_destroy_lock_async(char *lock_id, int mode, char *host_id, char *drive, uint64_t *handle);
 
 int idm_drive_async_result(char *drive, uint64_t handle, int *result);
 

--- a/src/idm_api.c
+++ b/src/idm_api.c
@@ -696,15 +696,17 @@ int idm_drive_read_group(char *drive, struct idm_info **info_ptr, int *info_num)
 }
 
 /**
- * idm_drive_destroy - Destroy an IDM and release all associated resource.
+ * idm_drive_destroy_lock - Destroy an IDM and release all associated resource.
  *
  * @lock_id:	Lock ID (64 bytes).
+ * @mode:	Lock mode (unlock, shareable, exclusive).
+ * @host_id:	Host ID (64 bytes).
  * @drive:	Drive path name.
  *
  * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
  */
-int idm_drive_destroy(char *lock_id, int mode, char *host_id,
-                      char *drive)
+int idm_drive_destroy_lock(char *lock_id, int mode, char *host_id,
+                           char *drive)
 {
 	int ret;
 
@@ -714,6 +716,33 @@ int idm_drive_destroy(char *lock_id, int mode, char *host_id,
 	else
 		ret = scsi_idm_sync_lock_destroy(lock_id, mode, host_id,
 		                                 drive);
+
+	return ret;
+}
+
+/**
+ * idm_drive_destroy_lock_async - Asynchronously destroy an IDM and release all
+ *                           associated resource.
+ *
+ * @lock_id:	Lock ID (64 bytes).
+ * @mode:	Lock mode (unlock, shareable, exclusive).
+ * @host_id:	Host ID (32 bytes).
+ * @drive:	Drive path name.
+ * @handle:	Returned request handle for device.
+ *
+ * Returns zero or a negative error (ie. EINVAL, ENOMEM, EBUSY, etc).
+ */
+int idm_drive_destroy_lock_async(char *lock_id, int mode, char *host_id,
+                                 char *drive, uint64_t *handle)
+{
+	int ret;
+
+	if (strstr(drive, NVME_DEVICE_TAG))
+		ret = nvme_idm_async_lock_destroy(lock_id, mode, host_id,
+		                                  drive, handle);
+	else
+		ret = scsi_idm_async_lock_destroy(lock_id, mode, host_id,
+		                                  drive, handle);
 
 	return ret;
 }

--- a/src/idm_api.h
+++ b/src/idm_api.h
@@ -17,13 +17,13 @@
 #define NVME_DEVICE_TAG "nvme"
 
 /*
- * NOTE: assumes the functions idm_drive_init() and idm_drive_destroy()
+ * NOTE: assumes the functions idm_drive_init() and idm_drive_destroy_lock()
  * will be used internally in IDM wrapper layer; so this can be transparent
  * to upper layer and reduce the complexity in raid lock layer.
  */
 #if 0
 int idm_drive_init(char *lock_id, char *host_id, char *drive);
-int idm_drive_destroy(char *lock_id, char *host_id, char *drive);
+int idm_drive_destroy_lock(char *lock_id, char *host_id, char *drive);
 #endif
 
 int idm_drive_version(char *drive, uint8_t *version_major, uint8_t *version_minor);
@@ -73,7 +73,8 @@ int idm_drive_lock_mode_async_result(char *drive, uint64_t handle, int *mode,
                                      int *result);
 int idm_drive_read_group(char *drive, struct idm_info **info_ptr,
                          int *info_num);
-int idm_drive_destroy(char *lock_id, int mode, char *host_id, char *drive);
+int idm_drive_destroy_lock(char *lock_id, int mode, char *host_id, char *drive);
+int idm_drive_destroy_lock_async(char *lock_id, int mode, char *host_id, char *drive, uint64_t *handle);
 int idm_drive_async_result(char *drive, uint64_t handle, int *result);
 int idm_drive_host_state(char *lock_id, char *host_id, int *host_state,
                          char *drive);

--- a/src/idm_pthread_backend.c
+++ b/src/idm_pthread_backend.c
@@ -1566,13 +1566,13 @@ int idm_drive_read_group(char *drive, struct idm_info **info_ptr, int *info_num)
 }
 
 /**
- * idm_drive_destroy - Destroy an IDM and release all associated resource.
+ * idm_drive_destroy_lock - Destroy an IDM and release all associated resource.
  * @lock_id:		Lock ID (64 bytes).
  * @drive:		Drive path name.
  *
  * Returns zero or a negative error (ie. EINVAL).
  */
-int idm_drive_destroy(char *lock_id, char *drive)
+int idm_drive_destroy_lock(char *lock_id, char *drive)
 {
 	struct idm_emulation *idm;
 	struct idm_host *host, *next;

--- a/src/idm_scsi.h
+++ b/src/idm_scsi.h
@@ -55,6 +55,7 @@ int scsi_idm_async_read_lock_mode(char *lock_id, char *drive, uint64_t *handle);
 int scsi_idm_async_get_result_lock_mode(uint64_t handle, int *mode, int *result);
 int scsi_idm_sync_read_mutex_group(char *drive, struct idm_info **info_ptr, int *info_num);
 int scsi_idm_sync_lock_destroy(char *lock_id, int mode, char *host_id, char *drive);
+int scsi_idm_async_lock_destroy(char *lock_id, int mode, char *host_id, char *drive, uint64_t *handle);
 
 int scsi_idm_async_get_result(uint64_t handle, int *result);
 

--- a/src/lock.c
+++ b/src/lock.c
@@ -482,6 +482,10 @@ int ilm_lock_release(struct ilm_cmd *cmd, struct ilm_lockspace *ls)
 
 	pthread_mutex_lock(&lock->mutex);
 	ret = idm_raid_unlock(lock, ls->host_id);
+	/* Blind destroy of every mutex acting as a rudimentary real-time
+	mutex cleanup mechanism.
+	Temp solution until max available mutexes can reliably be >128.
+	Requires firmware\software changes.*/
 	idm_raid_destroy_lock(lock, ls->host_id);
 	pthread_mutex_unlock(&lock->mutex);
 

--- a/src/lock.c
+++ b/src/lock.c
@@ -482,6 +482,7 @@ int ilm_lock_release(struct ilm_cmd *cmd, struct ilm_lockspace *ls)
 
 	pthread_mutex_lock(&lock->mutex);
 	ret = idm_raid_unlock(lock, ls->host_id);
+	idm_raid_destroy_lock(lock, ls->host_id);
 	pthread_mutex_unlock(&lock->mutex);
 
 	ilm_free(ls, lock);
@@ -757,6 +758,7 @@ out:
 int ilm_lock_terminate(struct ilm_lockspace *ls, struct ilm_lock *lock)
 {
 	idm_raid_unlock(lock, ls->host_id);
+	idm_raid_destroy_lock(lock, ls->host_id);
 	free(lock);
 
 	return 0;

--- a/src/raid_lock.h
+++ b/src/raid_lock.h
@@ -12,6 +12,7 @@ int idm_raid_lock(struct ilm_lock *lock, char *host_id);
 int idm_raid_unlock(struct ilm_lock *lock, char *host_id);
 int idm_raid_convert_lock(struct ilm_lock *lock, char *host_id, int mode);
 int idm_raid_renew_lock(struct ilm_lock *lock, char *host_id);
+int idm_raid_destroy_lock(struct ilm_lock *lock, char *host_id);
 int idm_raid_write_lvb(struct ilm_lock *lock, char *host_id,
 		       char *lvb, int lvb_size);
 int idm_raid_read_lvb(struct ilm_lock *lock, char *host_id,

--- a/test/idm_api_async_test.py
+++ b/test/idm_api_async_test.py
@@ -65,6 +65,16 @@ def test_idm__async_lock_exclusive(idm_async_daemon, reset_devices):
     assert ret == 0
     assert result == 0
 
+    ret, handle = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
+                                                       host_id0, SG_DEVICE1)
+    assert ret == 0
+
+    wait_for_scsi_response(SG_DEVICE1, handle)
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle)
+    assert ret == 0
+    assert result == 0
+
 def test_idm__async_lock_shareable(idm_async_daemon, reset_devices):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -100,6 +110,17 @@ def test_idm__async_lock_shareable(idm_async_daemon, reset_devices):
     ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle)
     assert ret == 0
     assert result == 0
+
+    ret, handle = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                                       host_id0, SG_DEVICE1)
+    assert ret == 0
+
+    wait_for_scsi_response(SG_DEVICE1, handle)
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle)
+    assert ret == 0
+    # assert result == 0
+    assert result == -2 #TODO: Should be 0, firmware fix required.  Destroy "result" normally ignored.
 
 def test_idm__async_lock_exclusive_two_drives(idm_async_daemon, reset_devices):
 
@@ -141,6 +162,25 @@ def test_idm__async_lock_exclusive_two_drives(idm_async_daemon, reset_devices):
 
     ret, handle2 = idm_api.idm_drive_unlock_async(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
                                                    host_id0, a, 8, SG_DEVICE2)
+    assert ret == 0
+
+    wait_for_scsi_response(SG_DEVICE1, handle1)
+    wait_for_scsi_response(SG_DEVICE2, handle2)
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle1)
+    assert ret == 0
+    assert result == 0
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE2, handle2)
+    assert ret == 0
+    assert result == 0
+
+    ret, handle1 = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
+                                                        host_id0, SG_DEVICE1)
+    assert ret == 0
+
+    ret, handle2 = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
+                                                        host_id0, SG_DEVICE2)
     assert ret == 0
 
     wait_for_scsi_response(SG_DEVICE1, handle1)
@@ -207,6 +247,27 @@ def test_idm__async_lock_shareable_two_drives(idm_async_daemon, reset_devices):
     assert ret == 0
     assert result == 0
 
+    ret, handle1 = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                                        host_id0, SG_DEVICE1)
+    assert ret == 0
+
+    ret, handle2 = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                                        host_id0, SG_DEVICE2)
+    assert ret == 0
+
+    wait_for_scsi_response(SG_DEVICE1, handle1)
+    wait_for_scsi_response(SG_DEVICE2, handle2)
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle1)
+    assert ret == 0
+    # assert result == 0
+    assert result == -2 #TODO: Should be 0, firmware fix required.  Destroy "result" normally ignored.
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE2, handle2)
+    assert ret == 0
+    # assert result == 0
+    assert result == -2 #TODO: Should be 0, firmware fix required.  Destroy "result" normally ignored.
+
 def test_idm__async_lock_shareable_two_locks(idm_async_daemon, reset_devices):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -222,7 +283,7 @@ def test_idm__async_lock_shareable_two_locks(idm_async_daemon, reset_devices):
     assert ret == 0
 
     wait_for_scsi_response(SG_DEVICE1, handle1)
-    wait_for_scsi_response(SG_DEVICE2, handle2)
+    wait_for_scsi_response(SG_DEVICE1, handle2)
 
     ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle1)
     assert ret == 0
@@ -251,7 +312,7 @@ def test_idm__async_lock_shareable_two_locks(idm_async_daemon, reset_devices):
     assert ret == 0
 
     wait_for_scsi_response(SG_DEVICE1, handle1)
-    wait_for_scsi_response(SG_DEVICE2, handle2)
+    wait_for_scsi_response(SG_DEVICE1, handle2)
 
     ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle1)
     assert ret == 0
@@ -260,6 +321,27 @@ def test_idm__async_lock_shareable_two_locks(idm_async_daemon, reset_devices):
     ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle2)
     assert ret == 0
     assert result == 0
+
+    ret, handle1 = idm_api.idm_drive_destroy_lock_async(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                                        host_id0, SG_DEVICE1)
+    assert ret == 0
+
+    ret, handle2 = idm_api.idm_drive_destroy_lock_async(lock_id1, idm_api.IDM_MODE_SHAREABLE,
+                                                        host_id0, SG_DEVICE1)
+    assert ret == 0
+
+    wait_for_scsi_response(SG_DEVICE1, handle1)
+    wait_for_scsi_response(SG_DEVICE1, handle2)
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle1)
+    assert ret == 0
+    # assert result == 0
+    assert result == -2 #TODO: Should be 0, firmware fix required.  Destroy "result" normally ignored.
+
+    ret, result = idm_api.idm_drive_async_result(SG_DEVICE1, handle2)
+    assert ret == 0
+    # assert result == 0
+    assert result == -2 #TODO: Should be 0, firmware fix required.  Destroy "result" normally ignored.
 
 def test_idm__async_break_lock_1(idm_async_daemon, reset_devices):
 

--- a/test/idm_api_test.py
+++ b/test/idm_api_test.py
@@ -44,6 +44,10 @@ def test_idm__sync_lock_exclusive(idm_sync_daemon, reset_devices):
 		    		    host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
+                                         host_id0, SG_DEVICE1)
+    assert ret == 0
+
 def test_idm__sync_lock_shareable(idm_sync_daemon, reset_devices):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -66,6 +70,10 @@ def test_idm__sync_lock_shareable(idm_sync_daemon, reset_devices):
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
 		    		    host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
+
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                         host_id0, SG_DEVICE1)
+    assert ret == -2 #TODO: Should be 0, firmware fix required.  Destroy "ret" normally ignored.
 
 def test_idm__sync_lock_exclusive_twice(idm_sync_daemon, reset_devices):
 
@@ -96,6 +104,10 @@ def test_idm__sync_lock_exclusive_twice(idm_sync_daemon, reset_devices):
 
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
 		    		    host_id0, a, 8, SG_DEVICE1)
+    assert ret == 0
+
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
+                                         host_id0, SG_DEVICE1)
     assert ret == 0
 
 def test_idm__sync_lock_shareable_twice(idm_sync_daemon, reset_devices):
@@ -129,6 +141,10 @@ def test_idm__sync_lock_shareable_twice(idm_sync_daemon, reset_devices):
 		    		    host_id0, a, 8, SG_DEVICE1)
     assert ret == -2
 
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                         host_id0, SG_DEVICE1)
+    assert ret == -2 #TODO: Should be 0, firmware fix required.  Destroy "ret" normally ignored.
+
 def test_idm__sync_lock_exclusive_two_hosts(idm_sync_daemon, reset_devices):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -161,6 +177,10 @@ def test_idm__sync_lock_exclusive_two_hosts(idm_sync_daemon, reset_devices):
 		    		    host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
 
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_EXCLUSIVE,
+                                         host_id0, SG_DEVICE1)
+    assert ret == 0
+
 def test_idm__sync_lock_shareable_two_hosts(idm_sync_daemon, reset_devices):
 
     lock_id0 = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -189,9 +209,17 @@ def test_idm__sync_lock_shareable_two_hosts(idm_sync_daemon, reset_devices):
 		    		    host_id0, a, 8, SG_DEVICE1)
     assert ret == 0
 
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                         host_id0, SG_DEVICE1)
+    assert ret == -16
+
     ret = idm_api.idm_drive_unlock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
 		    		    host_id1, a, 8, SG_DEVICE1)
     assert ret == 0
+
+    ret = idm_api.idm_drive_destroy_lock(lock_id0, idm_api.IDM_MODE_SHAREABLE,
+                                         host_id1, SG_DEVICE1)
+    assert ret == -2 #TODO: Should be 0, firmware fix required.  Destroy "ret" normally ignored.
 
 def test_idm__sync_break_lock_1(idm_sync_daemon, reset_devices):
 


### PR DESCRIPTION
Add destroy lock (async) cmd after every unlock (async) cmd.  This blind destroy of every mutex is acting as a rudimentary real-time mutex cleanup mechanism.  This is a temp solution until max available mutexes can reliably be >128.  Requires firmware\software changes to fix.

Primary changes consist of:
- Adding an new async destroy lock cmd to the scsi code.
- Adding a new ILM_OP_DESTROY cmd (using the above async destroy lock) to the ILM layer to allow re-utilization of the existing idm_raid_thread() framework that is used for issuing commands to the low-level IDM interface. Note that this destroy cmd has not been exposed "upward" toward the propeller cmd_handler.
- Unit test updates were kept to a minimum.  This is mainly due to the fact that destroying a shareable lock returns an unexpected error (while the exclusive locks do not).  Since this inconsistency creates undesired complexity within the more elaborate unit tests, the destroy lock cmd will only be tested in the fundamental unit tests to validate it's functionality. (This will be fixed at a later date).