### PR TITLE
FOSS-559 fix compilation error.

### DIFF
--- a/src/ilm.h
+++ b/src/ilm.h
@@ -35,7 +35,7 @@ struct idm_lock_op {
 	int timeout; /* -1 means unlimited timeout */
 };
 
-uuid_t ilm_uuid;
+extern uuid_t ilm_uuid;
 int ilm_connect(int *sock);
 int ilm_disconnect(int sock);
 int ilm_version(int sock, char *drive, uint8_t *version_major, uint8_t *version_minor);


### PR DESCRIPTION
Use extern to remove compilation error created by moving from 9.x gcc to 11.x gcc.