### PR TITLE
Fix libseagate_ilm.so metadata

### DIFF
--- a/src/libseagate_ilm.pc
+++ b/src/libseagate_ilm.pc
@@ -7,5 +7,5 @@ Name: libseagate_ilm
 Description: The Seagate In Drive Mutex (IDM) library
 Version: 0.1.0
 Cflags: -I${includedir}
-Libs: -L${libdir} -llibseagate_ilm
+Libs: -L${libdir} -lseagate_ilm
 


### PR DESCRIPTION
libseagate_ilm.pc provides package metadata for libseagate_ilm. The "Libs" attribute of this file provides an incorrect linking flag to pkg-config, which is used by the LVM build process. Should be "-lseagate_ilm"; the current value gets expanded to "liblibseagate" by the linker (and/or other build tools) and causes the LVM2 build to fail if IDM is enabled (as of LVM2 v2.03.21)